### PR TITLE
Remove [[workspace]] from Rita's Cargo.toml:

### DIFF
--- a/rita/Cargo.toml
+++ b/rita/Cargo.toml
@@ -20,5 +20,3 @@ serde = "1.0.24"
 serde_derive = "1.0.24"
 serde_json = "1.0.8"
 reqwest = "0.8.2"
-
-[workspace]


### PR DESCRIPTION
Cargo does not permit multiple workspace roots ([[workspace]]
declarations) which would prevent the package from building.

This commit removes the redundant workspace root.