### PR TITLE
Add travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+script:
+  - cargo build --verbose --all
+  - cargo test --verbose --all


### PR DESCRIPTION
DebtKeeper doens't seem to build right, so we should probably clean up our crates and then get this merged.

Should we test only nightly or all three release streams of rust?