### PR TITLE
Use build caching for Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+cache: cargo
 rust:
   - stable
   - beta


### PR DESCRIPTION
Travis has a rather easy to use build caching feature, seems like
a waste not to use it.