### PR TITLE
Update Travis to crosscompile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,18 @@ language: rust
 cache: cargo
 before_install:
   - sudo add-apt-repository ppa:wireguard/wireguard -y
+  - sudo add-apt-repository universe
   - sudo apt-get -qq update
-  - sudo apt-get install -y libsqlite3-dev iperf3 python3-pip bridge-utils wireguard linux-source linux-headers-$(uname -r)
+  - sudo apt-get install -y libsqlite3-dev iperf3 python3-pip bridge-utils wireguard linux-source linux-headers-$(uname -r) binutils-powerpc64le-linux-gnu gcc-powerpc64le-linux-gnu cpp-powerpc64le-linux-gnu curl git libssl-dev pkg-config
   - sudo pip3 install -r integration-tests/requirements.txt
   - which diesel || cargo install diesel_cli --no-default-features --features sqlite
+  - rustup target add powerpc64le-unknown-linux-gnu
+  - rustup update
+  - sudo cp /usr/include/x86_64-linux-gnu/openssl/* /usr/include/openssl/ 
 env:
   - TEST_COMMAND="cargo install rustfmt-nightly --force && cargo fmt --all -- --write-mode=diff"
   - TEST_COMMAND="cargo build --verbose --all"
+  - TEST_COMMAND="cargo build --target powerpc64le-unknown-linux-gnu --verbose --all" PKG_CONFIG_ALLOW_CROSS=1
   - TEST_COMMAND="cargo test --verbose --all" RUST_TEST_THREADS=1
   - TEST_COMMAND="./integration-tests/rita.sh"
 rust:


### PR DESCRIPTION
This crosscompiles to the powerpcle arch, just because that easy easily
available in Trusty and uncommon enough to break anything that will break
during a crosscompilation. When Xenial is availible we can add in mips and
mipsle