### PR TITLE
integration-tests: futureproofness & verbosity

### DIFF
--- a/integration-tests/rita.py
+++ b/integration-tests/rita.py
@@ -208,8 +208,8 @@ class World:
         for id, conn in self.connections.items():
             edges.append({
                 "nodes": ["{}".format(conn.a.id), "{}".format(conn.b.id)],
-                "->": "loss random 0%",
-                "<-": "loss random 0%"
+                "->": "",
+                "<-": ""
             })
 
         network = {"nodes": nodes, "edges": edges}

--- a/integration-tests/rita.sh
+++ b/integration-tests/rita.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 
 cd $(dirname $0)
 


### PR DESCRIPTION
This commit removes "loss random 0%" from the test netlab mesh
definition in rita.py (newer tc versions don't accept 0% losses for some
mysterious reason) and makes rita.sh more verbose (with `set -x` like in
babeld tests).