### PR TITLE
Add traffic forwarding rules for exit tunnel

### DIFF
--- a/clu/src/lib.rs
+++ b/clu/src/lib.rs
@@ -86,6 +86,11 @@ fn linux_setup_exit_tunnel(config: Arc<RwLock<settings::RitaSettingsStruct>>) ->
     )?;
     KI.set_route_to_tunnel(&details.server_internal_ip);
 
+    let lan_nics = &config.get_exit_tunnel_settings().lan_nics;
+    for nic in lan_nics {
+        KI.add_client_nat_rules(&nic);
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
This nat's traffic from the lan nics to the exit tunnel, we can't
use the openwrt firewall rules for this like before because it requires
that the interface be there on startup. Also this is a more portable solution
where a random linux machine can run Rita and forward traffic like a router
without anyone having to monkey around.

Two major things to be concerned about when working with this, if you restart
openwrt's firewall Rita will crash and these rules need to be reinserted, maybe
we should put a dep in there somehow so that they get restarted together.

Second mtu clamping, I'm not sure it's perfect yet.