### PR TITLE
Some code cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ lto = true
 codegen-units = 1
 incremental = false
 
-[features]
-default = []
-system_alloc = []
+[profile.dev]
+opt-level = "z"
+lto = true
+debug = false
+codegen-units = 1
+incremental = false
+

--- a/althea_kernel_interface/src/counter.rs
+++ b/althea_kernel_interface/src/counter.rs
@@ -1,10 +1,9 @@
-use super::{KernelInterface, KernelInterfaceError};
+use super::KernelInterface;
 
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::str::FromStr;
 
-use eui48::MacAddress;
 use regex::Regex;
 
 use failure::Error;
@@ -69,7 +68,7 @@ impl KernelInterface {
                 "inet6",
                 "counters",
             ],
-        );
+        ).expect("ipset failed to create counter");
         self.add_iptables_rule(
             "ip6tables",
             &[
@@ -88,7 +87,7 @@ impl KernelInterface {
                 target.set_name(),
                 &format!("dst,{}", target.interface()),
             ],
-        )?;
+        ).expect("iptables match rule failed");
         Ok(())
     }
 
@@ -106,7 +105,7 @@ impl KernelInterface {
                 "inet6",
                 "counters",
             ],
-        );
+        ).expect("ipset read counters failed!");
 
         self.run_command(
             "ipset",
@@ -115,7 +114,7 @@ impl KernelInterface {
                 &format!("tmp_{}", target.set_name()),
                 target.set_name(),
             ],
-        )?;
+        ).expect("ipset swap failed");
 
         let output = self.run_command("ipset", &["save", &format!("tmp_{}", target.set_name())])?;
         let res = parse_ipset(&String::from_utf8(output.stdout)?);

--- a/althea_kernel_interface/src/create_wg_key.rs
+++ b/althea_kernel_interface/src/create_wg_key.rs
@@ -1,9 +1,9 @@
-use super::{KernelInterface, KernelInterfaceError};
+use super::KernelInterface;
 
 use std::fs::File;
-use std::io::{BufRead, BufReader, BufWriter, Read, Write};
+use std::io::Write;
 use std::path::Path;
-use std::process::{Command, Output, Stdio};
+use std::process::{Command, Stdio};
 
 use failure::Error;
 
@@ -21,13 +21,13 @@ impl KernelInterface {
     }
 
     pub fn create_wg_keypair(&self) -> Result<[String; 2], Error> {
-        let mut genkey = Command::new("wg")
+        let genkey = Command::new("wg")
             .args(&["genkey"])
             .stdout(Stdio::piped())
             .output()
             .unwrap();
 
-        let mut genstdout = genkey.stdout;
+        let genstdout = genkey.stdout;
         let mut pubkey = Command::new("wg")
             .args(&["pubkey"])
             .stdout(Stdio::piped())
@@ -35,7 +35,7 @@ impl KernelInterface {
             .spawn()
             .unwrap();
 
-        pubkey.stdin.as_mut().unwrap().write_all(&genstdout);
+        pubkey.stdin.as_mut().unwrap().write_all(&genstdout).expect("Failure generating wg keypair!");
         let output = pubkey.wait_with_output().unwrap();
 
         let mut privkey_str = String::from_utf8(genstdout)?;
@@ -47,4 +47,4 @@ impl KernelInterface {
     }
 }
 
-//TODO some tests
+//Tested in CLU

--- a/althea_kernel_interface/src/exit_client_counter.rs
+++ b/althea_kernel_interface/src/exit_client_counter.rs
@@ -1,4 +1,4 @@
-use super::{KernelInterface, KernelInterfaceError};
+use super::KernelInterface;
 
 use failure::Error;
 

--- a/althea_kernel_interface/src/exit_client_tunnel.rs
+++ b/althea_kernel_interface/src/exit_client_tunnel.rs
@@ -3,7 +3,6 @@ use super::{KernelInterface, KernelInterfaceError};
 use failure::Error;
 
 use std::net::{IpAddr, SocketAddr};
-use std::str::FromStr;
 
 impl KernelInterface {
     pub fn set_client_exit_tunnel_config(
@@ -35,7 +34,7 @@ impl KernelInterface {
             ],
         )?;
 
-        let output = self.run_command(
+        let _output = self.run_command(
             "ip",
             &[
                 "address",
@@ -66,7 +65,7 @@ impl KernelInterface {
     }
 
     pub fn set_route_to_tunnel(&self, gateway: &IpAddr) -> Result<(), Error> {
-        self.run_command("ip", &["route", "del", "default"]);
+        self.run_command("ip", &["route", "del", "default"]).expect("Failed to delete default route");
 
         let output = self.run_command(
             "ip",
@@ -103,19 +102,19 @@ impl KernelInterface {
                 "-j",
                 "MASQUERADE",
             ],
-        );
+        ).expect("Failure setting client tunnel MASQ");
         self.add_iptables_rule(
             "iptables",
             &[
                 "-A", "FORWARD", "-i", &lan_nic, "-o", "wg_exit", "-j", "ACCEPT",
             ],
-        );
+        ).expect("Failure adding lan to wg_exit forward");
         self.add_iptables_rule(
             "iptables",
             &[
                 "-A", "FORWARD", "-i", "wg_exit", "-o", &lan_nic, "-j", "ACCEPT",
             ],
-        );
+        ).expect("Failure adding wg_exit to lan forward");
         self.add_iptables_rule(
             "iptables",
             &[
@@ -130,7 +129,7 @@ impl KernelInterface {
                 "TCPMSS",
                 "--clamp-mss-to-pmtu", //should be the same as --set-mss 1300
             ],
-        );
+        ).expect("Failure to clamp mss");
         //TODO ipv6 support
 
         Ok(())

--- a/althea_kernel_interface/src/exit_server_counter.rs
+++ b/althea_kernel_interface/src/exit_server_counter.rs
@@ -1,10 +1,9 @@
-use super::{KernelInterface, KernelInterfaceError};
+use super::KernelInterface;
 
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::str::FromStr;
 
-use eui48::MacAddress;
 use regex::Regex;
 
 use failure::Error;
@@ -71,7 +70,7 @@ impl KernelInterface {
                 "inet6",
                 "counters",
             ],
-        );
+        ).expect("ipset init failed");
         self.add_iptables_rule(
             "ip6tables",
             &[
@@ -90,7 +89,7 @@ impl KernelInterface {
                 target.set_name(),
                 target.direction(),
             ],
-        )?;
+        ).expect("ip6tables counter failed");
         Ok(())
     }
 
@@ -108,7 +107,7 @@ impl KernelInterface {
                 "inet6",
                 "counters",
             ],
-        );
+        ).expect("Failed to create new ipset to swap");
 
         self.run_command(
             "ipset",
@@ -117,7 +116,7 @@ impl KernelInterface {
                 &format!("tmp_{}", target.set_name()),
                 target.set_name(),
             ],
-        )?;
+        ).expect("failed to swap ipset rules");
 
         let output = self.run_command("ipset", &["save", &format!("tmp_{}", target.set_name())])?;
         let res = parse_exit_ipset(&String::from_utf8(output.stdout)?);

--- a/althea_kernel_interface/src/exit_server_tunnel.rs
+++ b/althea_kernel_interface/src/exit_server_tunnel.rs
@@ -2,9 +2,7 @@ use super::{KernelInterface, KernelInterfaceError};
 
 use failure::Error;
 
-use std::collections::HashMap;
-use std::net::{IpAddr, SocketAddr};
-use std::str::FromStr;
+use std::net::IpAddr;
 
 #[derive(Debug)]
 pub struct ExitClient {
@@ -48,7 +46,7 @@ impl KernelInterface {
 
         self.run_command(&command, &arg_str[..])?;
 
-        let output = self.run_command(
+        let _output = self.run_command(
             "ip",
             &[
                 "address",

--- a/althea_kernel_interface/src/get_neighbors.rs
+++ b/althea_kernel_interface/src/get_neighbors.rs
@@ -1,9 +1,8 @@
-use super::{KernelInterface, KernelInterfaceError};
+use super::KernelInterface;
 
 use std::net::IpAddr;
 use std::str::FromStr;
 
-use eui48::MacAddress;
 use regex::Regex;
 
 use failure::Error;

--- a/althea_kernel_interface/src/get_wg_pubkey.rs
+++ b/althea_kernel_interface/src/get_wg_pubkey.rs
@@ -1,9 +1,0 @@
-use super::{KernelInterface, KernelInterfaceError};
-
-use std::fs::File;
-use std::path::Path;
-use std::process::{Command, Stdio};
-
-use failure::Error;
-
-impl KernelInterface {}

--- a/althea_kernel_interface/src/interface_tools.rs
+++ b/althea_kernel_interface/src/interface_tools.rs
@@ -1,6 +1,5 @@
-use super::{KernelInterface, KernelInterfaceError};
+use super::KernelInterface;
 
-use std::net::IpAddr;
 
 use regex::Regex;
 

--- a/althea_kernel_interface/src/ip_route.rs
+++ b/althea_kernel_interface/src/ip_route.rs
@@ -1,4 +1,4 @@
-use super::{KernelInterface, KernelInterfaceError};
+use super::KernelInterface;
 
 use std::net::IpAddr;
 

--- a/althea_kernel_interface/src/lib.rs
+++ b/althea_kernel_interface/src/lib.rs
@@ -9,18 +9,12 @@ extern crate eui48;
 extern crate itertools;
 extern crate regex;
 
-use std::borrow::BorrowMut;
-use std::cell::RefCell;
-use std::ffi::OsStr;
-use std::io::Write;
-use std::path::Path;
 use std::process::{Command, Output};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use std::str;
 
-use eui48::MacAddress;
 
 mod counter;
 mod create_wg_key;
@@ -30,7 +24,6 @@ mod exit_client_tunnel;
 mod exit_server_counter;
 mod exit_server_tunnel;
 mod get_neighbors;
-mod get_wg_pubkey;
 mod interface_tools;
 mod ip_route;
 mod iptables;
@@ -95,7 +88,7 @@ impl CommandRunner for LinuxCommandRunner {
         return Ok(output);
     }
 
-    fn set_mock(&self, mock: Box<FnMut(String, Vec<String>) -> Result<Output, Error> + Send>) {
+    fn set_mock(&self, _mock: Box<FnMut(String, Vec<String>) -> Result<Output, Error> + Send>) {
         unimplemented!()
     }
 }

--- a/althea_kernel_interface/src/link_local_tools.rs
+++ b/althea_kernel_interface/src/link_local_tools.rs
@@ -1,9 +1,6 @@
 use super::{KernelInterface, KernelInterfaceError};
 
-use std::fs::File;
-use std::io::{Read, Write};
 use std::net::IpAddr;
-use std::str::FromStr;
 
 use regex::Regex;
 

--- a/althea_kernel_interface/src/manipulate_uci.rs
+++ b/althea_kernel_interface/src/manipulate_uci.rs
@@ -28,7 +28,7 @@ impl KernelInterface {
 
     //Sets an arbitrary UCI list on OpenWRT
     pub fn set_uci_list(&self, key: &str, value: &[&str]) -> Result<bool, Error> {
-        self.del_uci_var(&key);
+        self.del_uci_var(&key)?;
         for v in value {
             self.run_uci("uci", &["add_list", &format!("{}={}", &key, &v)])?;
         }

--- a/althea_kernel_interface/src/open_tunnel.rs
+++ b/althea_kernel_interface/src/open_tunnel.rs
@@ -1,12 +1,12 @@
 use super::{KernelInterface, KernelInterfaceError};
 
-use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6};
+use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use std::path::Path;
 
 use failure::Error;
 
 #[derive(Debug, Fail)]
-pub enum TunnelOpeningError {
+pub enum _TunnelOpeningError {
     #[fail(display = "Link local without interface")]
     InvalidSocket,
 }
@@ -109,7 +109,7 @@ impl KernelInterface {
                 String::from_utf8(output.stderr)?
             )).into());
         }
-        let output = self.run_command(
+        let _output = self.run_command(
             "ip",
             &["address", "add", &format!("{}", own_ip), "dev", &interface],
         )?;

--- a/althea_kernel_interface/src/openwrt_ubus.rs
+++ b/althea_kernel_interface/src/openwrt_ubus.rs
@@ -1,6 +1,4 @@
-use super::{KernelInterface, KernelInterfaceError};
-
-use std::net::IpAddr;
+use super::KernelInterface;
 
 use failure::Error;
 

--- a/althea_kernel_interface/src/setup_wg_if.rs
+++ b/althea_kernel_interface/src/setup_wg_if.rs
@@ -1,7 +1,5 @@
 use super::{KernelInterface, KernelInterfaceError};
 
-use std::net::IpAddr;
-
 use failure::Error;
 
 impl KernelInterface {

--- a/althea_kernel_interface/src/stats.rs
+++ b/althea_kernel_interface/src/stats.rs
@@ -1,6 +1,4 @@
-use super::{KernelInterface, KernelInterfaceError};
-
-use std::collections::HashMap;
+use super::KernelInterface;
 
 use failure::Error;
 use std::fs::File;

--- a/clu/src/lib.rs
+++ b/clu/src/lib.rs
@@ -25,8 +25,6 @@ extern crate althea_kernel_interface;
 use althea_types::interop::ExitServerIdentity;
 use regex::Regex;
 use settings::ExitClientDetails;
-use std::fs::File;
-use std::io::Write;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
 use std::thread;
@@ -65,7 +63,7 @@ fn linux_generate_mesh_ip(config: &mut NetworkSettings) -> Result<(), Error> {
 }
 
 fn validate_wg_key(key: &str) -> bool {
-    key.len() == 44 && key.ends_with("=")
+    key.len() == 44 && key.ends_with("=") && !key.contains(" ")
 }
 
 fn validate_mesh_ip(ip: &IpAddr) -> bool {
@@ -84,11 +82,11 @@ fn linux_setup_exit_tunnel(config: Arc<RwLock<settings::RitaSettingsStruct>>) ->
         details.own_internal_ip,
         details.netmask,
     )?;
-    KI.set_route_to_tunnel(&details.server_internal_ip);
+    KI.set_route_to_tunnel(&details.server_internal_ip).expect("Failed to set default route");
 
     let lan_nics = &config.get_exit_tunnel_settings().lan_nics;
     for nic in lan_nics {
-        KI.add_client_nat_rules(&nic);
+        KI.add_client_nat_rules(&nic).expect("Failed to add LAN NAT");
     }
 
     Ok(())
@@ -137,17 +135,17 @@ pub fn cleanup() -> Result<(), Error> {
 
     for i in interfaces {
         if re.is_match(&i) {
-            KI.del_interface(&i)?;
+            KI.del_interface(&i).expect("failed to delete a w# interface");
         }
     }
 
-    KI.del_interface("wg_exit");
+    KI.del_interface("wg_exit").expect("failed to delete wg_exit");
     Ok(())
 }
 
 fn linux_init(config: Arc<RwLock<settings::RitaSettingsStruct>>) -> Result<(), Error> {
     cleanup()?;
-    KI.restore_default_route(&mut config.set_network().default_route);
+    KI.restore_default_route(&mut config.set_network().default_route)?;
 
     let privkey = config.get_network().wg_private_key.clone();
     let pubkey = config.get_network().wg_public_key.clone();
@@ -170,7 +168,7 @@ fn linux_init(config: Arc<RwLock<settings::RitaSettingsStruct>>) -> Result<(), E
         if config.exit_client_is_set() {
             let our_exit_ip = config.get_exit_client().exit_ip.clone();
 
-            assert!(!our_exit_ip.is_ipv4());
+            assert!(our_exit_ip.is_ipv6());
             assert!(!our_exit_ip.is_unspecified());
 
             let details = request_own_exit_ip(config.clone());
@@ -241,9 +239,13 @@ mod tests {
         let good_key = "8BeCExnthLe5ou0EYec5jNqJ/PduZ1x2o7lpXJOpgXk=";
         let bad_key1 = "8BeCExnthLe5ou0EYec5jNqJ/PduZ1x2o7lpXJOpXk=";
         let bad_key2 = "look at me, I'm the same length as a key but";
+        let bad_key3 = "8BeCExnthLe5ou0EYec5jNqJ/PduZ1x2o7lpXJOpXkk";
+        let bad_key4 = "8BeCExnthLe5ou0EYe 5jNqJ/PduZ1x2o7lpXJOpXkk";
         assert_eq!(validate_wg_key(&good_key), true);
         assert_eq!(validate_wg_key(&bad_key1), false);
         assert_eq!(validate_wg_key(&bad_key2), false);
+        assert_eq!(validate_wg_key(&bad_key3), false);
+        assert_eq!(validate_wg_key(&bad_key4), false);
     }
 
     #[test]

--- a/rita/Cargo.toml
+++ b/rita/Cargo.toml
@@ -11,6 +11,10 @@ path = "src/exit.rs"
 name = "rita"
 path = "src/client.rs"
 
+[features]
+default = []
+system_alloc = []
+
 [dependencies]
 clippy = { version = "*", optional = true }
 babel_monitor = { path = "../babel_monitor" }


### PR DESCRIPTION
Just some basic code cleanup and other helpful stuff. 

No more warnings in Kernel interface, but I've identified a few spots I would like to unit test, mostly to make sure code changes don't screw with proper output parsing for some of these commands. Otherwise the command runner and return codes make for pretty good coverage of failure cases. 