### PR TITLE
Add babel_monitor mocking + adjust other modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ name = "babel_monitor"
 version = "0.1.0"
 dependencies = [
  "ascii 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "derive-error 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ip_network 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockstream 0.0.3 (git+https://github.com/lazy-bitfield/rust-mockstream.git)",
@@ -302,11 +302,6 @@ dependencies = [
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "case"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cc"
@@ -478,16 +473,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "derive-error"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "case 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2435,7 +2420,6 @@ dependencies = [
 "checksum bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b7db437d718977f6dc9b2e3fd6fc343c02ac6b899b73fdd2179163447bd9ce9"
 "checksum cargo_metadata 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "be1057b8462184f634c3a208ee35b0f935cfd94b694b26deadccd98732088d7b"
 "checksum cargo_metadata 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1f56ec3e469bca7c276f2eea015aa05c5e381356febdbb0683c2580189604537"
-"checksum case 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e88b166b48e29667f5443df64df3c61dc07dc2b1a0b0d231800e07f09a33ecc1"
 "checksum cc 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9be26b24e988625409b19736d130f0c7d224f01d06454b5f81d8d23d6c1a618f"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
@@ -2452,7 +2436,6 @@ dependencies = [
 "checksum crossbeam-epoch 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9898f21d6d647793e163c804944941fb19aecd1f4a1a4c254bbb0bee15ccdea5"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
-"checksum derive-error 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ec098440b29ea3b1ece3e641bac424c19cf996779b623c9e0f2171495425c2c8"
 "checksum diesel 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925325c57038f2f14c0413bdf6a92ca72acff644959d0a1a9ebf8d19be7e9c01"
 "checksum diesel_derives 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "28e2b2605ac6a3b9a586383f5f8b2b5f1108f07a421ade965b266289d2805e79"
 "checksum docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d8acd393692c503b168471874953a2531df0e9ab77d0b6bbc582395743300a4a"

--- a/althea_kernel_interface/src/create_wg_key.rs
+++ b/althea_kernel_interface/src/create_wg_key.rs
@@ -34,7 +34,12 @@ impl KernelInterface {
             .spawn()
             .unwrap();
 
-        pubkey.stdin.as_mut().unwrap().write_all(&genkey.stdout).expect("Failure generating wg keypair!");
+        pubkey
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all(&genkey.stdout)
+            .expect("Failure generating wg keypair!");
         let output = pubkey.wait_with_output().unwrap();
 
         let mut privkey_str = String::from_utf8(genkey.stdout)?;

--- a/althea_kernel_interface/src/exit_client_tunnel.rs
+++ b/althea_kernel_interface/src/exit_client_tunnel.rs
@@ -67,7 +67,7 @@ impl KernelInterface {
     pub fn set_route_to_tunnel(&self, gateway: &IpAddr) -> Result<(), Error> {
         match self.run_command("ip", &["route", "del", "default"]) {
             Err(e) => warn!("Failed to delete default route {:?}", e),
-            _ => ()
+            _ => (),
         };
 
         let output = self.run_command(

--- a/althea_kernel_interface/src/exit_server_counter.rs
+++ b/althea_kernel_interface/src/exit_server_counter.rs
@@ -110,7 +110,7 @@ impl KernelInterface {
         );
         match ipset_result {
             Err(e) => warn!("ipset tmp creation failed with {:?}", e),
-            _ => ()
+            _ => (),
         };
 
         self.run_command(

--- a/althea_kernel_interface/src/lib.rs
+++ b/althea_kernel_interface/src/lib.rs
@@ -15,7 +15,6 @@ use std::time::Instant;
 
 use std::str;
 
-
 mod counter;
 mod create_wg_key;
 mod delete_tunnel;

--- a/althea_kernel_interface/src/manipulate_uci.rs
+++ b/althea_kernel_interface/src/manipulate_uci.rs
@@ -29,8 +29,8 @@ impl KernelInterface {
     //Sets an arbitrary UCI list on OpenWRT
     pub fn set_uci_list(&self, key: &str, value: &[&str]) -> Result<bool, Error> {
         match self.del_uci_var(&key) {
-            Err(e) => trace!("Delete uci var failed! {:?}",e),
-            _ => ()
+            Err(e) => trace!("Delete uci var failed! {:?}", e),
+            _ => (),
         };
 
         for v in value {

--- a/babel_monitor/Cargo.toml
+++ b/babel_monitor/Cargo.toml
@@ -7,5 +7,5 @@ authors = ["jkilpatr <jkilpatr@redhat.com>"]
 mockstream = { git = "https://github.com/lazy-bitfield/rust-mockstream.git" }
 ascii = "0.8.6"
 ip_network = "0.1"
-derive-error = "0.0.4"
+failure = "0.1.1"
 log = "^0.4"

--- a/babel_monitor/src/lib.rs
+++ b/babel_monitor/src/lib.rs
@@ -82,8 +82,6 @@ impl Babel for TcpStream {}
 impl Babel for SharedMockStream {}
 
 pub trait Babel: Read + Write {
-    /// Apart from just retrieving latest babeld output, this method also checks that the output
-    /// was one connected to a successful operation.
     fn read_babel(&mut self) -> Result<String, Error> {
         let mut reader = BufReader::new(self);
         let mut ret = String::new();

--- a/clu/src/lib.rs
+++ b/clu/src/lib.rs
@@ -137,14 +137,14 @@ pub fn cleanup() -> Result<(), Error> {
         if re.is_match(&i) {
             match KI.del_interface(&i) {
                 Err(e) => trace!("Failed to delete wg# {:?}", e),
-                _ => ()
-    };
+                _ => (),
+            };
         }
     }
 
     match KI.del_interface("wg_exit") {
         Err(e) => trace!("Failed to delete wg_exit {:?}", e),
-        _ => ()
+        _ => (),
     };
 
     Ok(())

--- a/rita/src/rita_common/tunnel_manager/mod.rs
+++ b/rita/src/rita_common/tunnel_manager/mod.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::net::{IpAddr, SocketAddr, SocketAddrV6};
+use std::net::{IpAddr, SocketAddr, SocketAddrV4, SocketAddrV6, TcpStream};
 use std::path::Path;
 
 use actix::actors;
@@ -22,7 +22,6 @@ use settings::RitaCommonSettings;
 use SETTING;
 
 use failure::Error;
-use std::net::SocketAddrV4;
 
 #[cfg(test)]
 type HTTPClient = Mocker<rita_common::http_client::HTTPClient>;
@@ -352,11 +351,12 @@ impl TunnelManager {
             &mut SETTING.set_network().default_route,
         )?;
 
-        let mut babel = Babel::new(&format!("[::1]:{}", SETTING.get_network().babel_port)
-            .parse()
-            .unwrap());
+        let mut babel: Box<Babel> = Box::new(TcpStream::connect::<SocketAddr>(format!(
+            "[::1]:{}",
+            SETTING.get_network().babel_port
+        ).parse()?)?);
 
-        // babel.redistribute_ip(&SETTING.get_network().own_ip, true)?;
+        babel.start_connection()?;
         babel.monitor(&tunnel.iface_name)?;
         Ok(())
     }


### PR DESCRIPTION
This commit makes the Babel struct into a trait that lets you mock it
with anything `Read + Write`.

babel_monitor/src/lib.rs:
* Add the new Babel trait + impls for TcpStream and SharedMockStream
* Adjust tests
* derive-error -> failure
* weed out all warnings

rita_client::traffic_watcher:
rita_common::traffic_watcher:
rita_common::tunnel_manager:
rita_exit::traffic_watcher:
* Adjust for new babel_monitor API
* Remove unwraps from `Watch` handlers