### PR TITLE
Fix Babel testing problems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,8 @@ name = "babel_monitor"
 version = "0.1.0"
 dependencies = [
  "ascii 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bufstream 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ip_network 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -256,6 +258,11 @@ dependencies = [
  "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "bufstream"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "build_const"
@@ -1608,6 +1615,7 @@ dependencies = [
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "minihttpse 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mockstream 0.0.3 (git+https://github.com/lazy-bitfield/rust-mockstream.git)",
  "num256 0.1.0",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2414,6 +2422,7 @@ dependencies = [
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum buf_redux 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b9279646319ff816b05fb5897883ece50d7d854d12b59992683d4f8a71b0f949"
+"checksum bufstream 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f382711e76b9de6c744cc00d0497baba02fb00a787f088c879f01d09468e32"
 "checksum build_const 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e90dc84f5e62d2ebe7676b83c22d33b6db8bd27340fb6ffbff0a364efa0cb9c9"
 "checksum bytecount 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "af27422163679dea46a1a7239dffff64d3dcdc3ba5fe9c49c789fbfe0eb949de"
 "checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"

--- a/babel_monitor/Cargo.toml
+++ b/babel_monitor/Cargo.toml
@@ -6,6 +6,8 @@ authors = ["jkilpatr <jkilpatr@redhat.com>"]
 [dependencies]
 mockstream = { git = "https://github.com/lazy-bitfield/rust-mockstream.git" }
 ascii = "0.8.6"
+bufstream = "0.1"
 ip_network = "0.1"
 failure = "0.1.1"
 log = "^0.4"
+env_logger = "0.5"

--- a/babel_monitor/src/lib.rs
+++ b/babel_monitor/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate bufstream;
 #[macro_use]
 extern crate failure;
 extern crate ip_network;
@@ -6,14 +7,14 @@ extern crate log;
 extern crate mockstream;
 
 use std::collections::VecDeque;
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{BufRead, Read, Write};
+use std::iter::Iterator;
 use std::net::IpAddr;
-use std::net::TcpStream;
 use std::str;
 
+use bufstream::BufStream;
 use failure::Error;
 use ip_network::IpNetwork;
-use mockstream::SharedMockStream;
 
 #[derive(Debug, Fail)]
 pub enum BabelMonitorError {
@@ -23,8 +24,12 @@ pub enum BabelMonitorError {
     InvalidPreamble(String),
     #[fail(display = "Could not find local fee in '{}'", _0)]
     LocalFeeNotFound(String),
-    #[fail(display = "Last Babel command failed with output:\n{}", _0)]
-    CommandFailed(String),
+    #[fail(display = "Command '{}' failed. {}", _0, _1)]
+    CommandFailed(String, String),
+    #[fail(display = "Erroneous Babel output:\n{}", _0)]
+    ReadFailed(String),
+    #[fail(display = "No terminator after Babel output:\n{}", _0)]
+    NoTerminator(String),
 }
 
 use BabelMonitorError::*;
@@ -42,14 +47,6 @@ fn find_babel_val(val: &str, line: &str) -> Result<String, Error> {
         }
     }
     return Err(VariableNotFound(String::from(val), String::from(line)).into());
-}
-
-fn is_terminator(line: &String) -> bool {
-    line == "ok" || line == "no" || line == "bad"
-}
-
-fn positive_termination(message: &String) -> bool {
-    message.contains("\nok\n")
 }
 
 #[derive(Debug)]
@@ -78,44 +75,64 @@ pub struct Neighbor {
     pub cost: u16,
 }
 
-impl Babel for TcpStream {}
-impl Babel for SharedMockStream {}
+pub struct Babel<T: Read + Write> {
+    stream: BufStream<T>,
+}
 
-pub trait Babel: Read + Write {
+impl<T: Read + Write> Babel<T> {
+    pub fn new(stream: T) -> Babel<T> {
+        Babel {
+            stream: BufStream::new(stream),
+        }
+    }
+
     fn read_babel(&mut self) -> Result<String, Error> {
-        let mut reader = BufReader::new(self);
         let mut ret = String::new();
-        for line in reader.by_ref().lines() {
+        for line in Read::by_ref(&mut self.stream).lines() {
             let line = &line?;
             ret.push_str(line);
             ret.push_str("\n");
-            if is_terminator(line) {
-                break;
+            match line.as_str().trim() {
+                "ok" => {
+                    trace!(
+                        "Babel returned ok; full output:\n{}\nEND OF BABEL OUTPUT",
+                        ret
+                    );
+                    return Ok(ret);
+                }
+                "bad" | "no" => {
+                    error!(
+                        "Babel returned bad/no; full output:\n{}\nEND OF BABEL OUTPUT",
+                        ret
+                    );
+                    return Err(ReadFailed(ret).into());
+                }
+                _ => continue,
             }
         }
-        trace!("babel returned {}", ret);
-        if ret.ends_with("ok\n") {
-            Ok(ret)
-        } else {
-            Err(CommandFailed(ret).into())
+        error!(
+            "Terminator was never found; full output:\n{:?}\nEND OF BABEL OUTPUT",
+            ret
+        );
+        return Err(NoTerminator(ret).into());
+    }
+
+    fn command(&mut self, cmd: &str) -> Result<String, Error> {
+        self.stream.write_all(format!("{}\n", cmd).as_bytes())?;
+        self.stream.flush()?;
+
+        trace!("Sent '{}' to babel", cmd);
+        match self.read_babel() {
+            Ok(out) => Ok(out),
+            Err(e) => Err(CommandFailed(String::from(cmd), e.to_string()).into()),
         }
     }
 
-    fn write_babel(&mut self, command: &str) -> Result<(), Error> {
-        self.write_all(command.as_bytes())?;
-        trace!("sent {} to babel", command);
-        Ok(())
-    }
-}
-
-impl Babel {
     // Consumes the automated Preamble and validates configuration api version
     pub fn start_connection(&mut self) -> Result<(), Error> {
-        trace!("About to get the preamble");
         let preamble = self.read_babel()?;
-        trace!("Got the preamble: {}", preamble);
         // Note you have changed the config interface, bump to 1.1 in babel
-        if preamble.contains("ALTHEA 0.1") && positive_termination(&preamble) {
+        if preamble.contains("ALTHEA 0.1") {
             info!("Attached OK to Babel with preamble: {}", preamble);
             return Ok(());
         } else {
@@ -124,9 +141,7 @@ impl Babel {
     }
 
     pub fn local_fee(&mut self) -> Result<u32, Error> {
-        self.write_babel("dump\n")?;
-
-        let babel_output = self.read_babel()?;
+        let babel_output = self.command("dump")?;
         let fee_entry = match babel_output.split("\n").nth(0) {
             Some(entry) => entry,
             // Even an empty string wouldn't yield None
@@ -143,35 +158,31 @@ impl Babel {
     }
 
     pub fn monitor(&mut self, iface: &str) -> Result<(), Error> {
-        let commmand = format!("interface {} \n", iface);
-        self.write_babel(&commmand)?;
-        let _ = self.read_babel()?;
+        let _ = self.command(&format!("interface {}", iface))?;
         info!("Babel started monitoring: {}", iface);
         Ok(())
     }
 
     pub fn redistribute_ip(&mut self, ip: &IpAddr, allow: bool) -> Result<(), Error> {
         let commmand = format!(
-            "redistribute ip {}/128 {}\n",
+            "redistribute ip {}/128 {}",
             ip,
             if allow { "allow" } else { "deny" }
         );
-        self.write_babel(&commmand)?;
+        self.command(&commmand)?;
         let _ = self.read_babel()?;
         Ok(())
     }
 
     pub fn unmonitor(&mut self, iface: &str) -> Result<(), Error> {
-        let commmand = format!("unmonitor {}\n", iface);
-        self.write_babel(&commmand)?;
+        self.command(&format!("unmonitor {}\n", iface))?;
         let _ = self.read_babel()?;
         Ok(())
     }
 
     pub fn parse_neighs(&mut self) -> Result<VecDeque<Neighbor>, Error> {
         let mut vector: VecDeque<Neighbor> = VecDeque::with_capacity(5);
-        self.write_babel("dump\n")?;
-        for entry in self.read_babel()?.split("\n") {
+        for entry in self.command("dump")?.split("\n") {
             if entry.contains("add neighbour") {
                 vector.push_back(Neighbor {
                     id: find_babel_val("neighbour", entry)?,
@@ -190,8 +201,7 @@ impl Babel {
 
     pub fn parse_routes(&mut self) -> Result<VecDeque<Route>, Error> {
         let mut vector: VecDeque<Route> = VecDeque::with_capacity(20);
-        self.write_babel("dump\n")?;
-        let babel_out = self.read_babel()?;
+        let babel_out = self.command("dump")?;
         trace!("Got from babel dump: {}", babel_out);
 
         for entry in babel_out.split("\n") {
@@ -218,9 +228,8 @@ impl Babel {
 #[cfg(test)]
 mod tests {
     use super::*;
-    static TABLE: &'static str =
-"local fee 1024\n\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\
-\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\
+    use mockstream::SharedMockStream;
+    static TABLE: &'static str = "local fee 1024\n\
 add interface wlan0 up true ipv6 fe80::1a8b:ec1:8542:1bd8 ipv4 10.28.119.131\n\
 add interface wg0 up true ipv6 fe80::2cee:2fff:7380:8354 ipv4 10.0.236.201\n\
 add neighbour 14f19a8 address fe80::2cee:2fff:648:8796 if wg0 reach ffff rxcost 256 txcost 256 rtt \
@@ -240,12 +249,11 @@ add route 14f06d8 prefix 10.28.20.151/32 from 0.0.0.0/0 installed yes id ba:27:e
 metric 817 price 4008 fee 4008 refmetric 0 via fe80::e9d0:498f:6c61:be29 if wlan0\n\
 add route 14f0548 prefix 10.28.244.138/32 from 0.0.0.0/0 installed yes id ba:27:eb:ff:fe:d1:3e:ba\
 metric 958 price 2048 fee 2048 refmetric 0 via fe80::e914:2335:a76:bda3 if wlan0\n\
-ok\n\u{0}\u{0}";
+ok\n";
 
     static PREAMBLE: &'static str =
         "ALTHEA 0.1\nversion babeld-1.8.0-24-g6335378\nhost raspberrypi\nmy-id \
-         ba:27:eb:ff:fe:09:06:dd\nok\n\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\
-         \u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}";
+         ba:27:eb:ff:fe:09:06:dd\nok\n";
 
     static XROUTE_LINE: &'static str =
         "add xroute 10.28.119.131/32-::/0 prefix 10.28.119.131/32 from ::/0 metric 0";
@@ -264,18 +272,11 @@ ok\n\u{0}\u{0}";
 
     static PRICE_LINE: &'static str = "local price 1024";
 
-    /*fn real_babel_basic() {
-      let mut b1 = Babel {stream: NetStream::Tcp(TcpStream::connect("::1:8080").unwrap())};
-      assert_eq!(b1.start_connection(), true);
-      assert_eq!(b1.write("dump\n"), true);
-      println!("{:?}", b1.read());
-      }*/
-
     #[test]
     fn mock_connect() {
         let mut s = SharedMockStream::new();
         s.push_bytes_to_read(PREAMBLE.as_bytes());
-        let b: &mut Babel = &mut s;
+        let mut b = Babel::new(s);
         b.start_connection().unwrap()
     }
 
@@ -311,10 +312,8 @@ ok\n\u{0}\u{0}";
     fn neigh_parse() {
         let mut s = SharedMockStream::new();
         s.push_bytes_to_read(TABLE.as_bytes());
-        s.write(b"dump\n").unwrap();
-        let b: &mut Babel = &mut s;
+        let mut b = Babel::new(s);
         let neighs = b.parse_neighs().unwrap();
-        println!("{:?}", neighs);
         let neigh = neighs.get(0);
         assert!(neigh.is_some());
         let neigh = neigh.unwrap();
@@ -326,8 +325,7 @@ ok\n\u{0}\u{0}";
     fn route_parse() {
         let mut s = SharedMockStream::new();
         s.push_bytes_to_read(TABLE.as_bytes());
-        s.write(b"dump\n").unwrap();
-        let b: &mut Babel = &mut s;
+        let mut b = Babel::new(s);
 
         let routes = b.parse_routes().unwrap();
         assert_eq!(routes.len(), 4);
@@ -340,9 +338,36 @@ ok\n\u{0}\u{0}";
     fn local_fee_parse() {
         let mut s = SharedMockStream::new();
         s.push_bytes_to_read(TABLE.as_bytes());
-        s.write(b"dump\n").unwrap();
-        let b: &mut Babel = &mut s;
 
+        let mut b = Babel::new(s);
         assert_eq!(b.local_fee().unwrap(), 1024);
+    }
+
+    #[test]
+    fn multiple_babel_outputs_in_stream() {
+        let mut s = SharedMockStream::new();
+        s.push_bytes_to_read(PREAMBLE.as_bytes());
+        s.push_bytes_to_read(TABLE.as_bytes());
+        s.push_bytes_to_read(b"ok\n");
+
+        let mut b = Babel::new(s);
+        b.start_connection().unwrap();
+
+        let routes = b.parse_routes().unwrap();
+        assert_eq!(routes.len(), 4);
+
+        let route = routes.get(0).unwrap();
+        assert_eq!(route.price, 3072);
+
+        b.command("interface wg0").unwrap();
+    }
+
+    #[test]
+    fn only_ok_in_output() {
+        let mut s = SharedMockStream::new();
+        s.push_bytes_to_read(b"ok\n");
+
+        let mut b = Babel::new(s);
+        b.command("interface wg0").unwrap();
     }
 }

--- a/rita/Cargo.toml
+++ b/rita/Cargo.toml
@@ -16,35 +16,36 @@ default = []
 system_alloc = []
 
 [dependencies]
-clippy = { version = "*", optional = true }
-babel_monitor = { path = "../babel_monitor" }
-diesel = { version = "1.0.0", features = ["sqlite"] }
-dotenv = "0.9.0"
-althea_types = { path = "../althea_types", features = ["actix"]}
 althea_kernel_interface = { path = "../althea_kernel_interface" }
-exit_db = { path = "../exit_db" }
-settings = { path = "../settings" }
+althea_types = { path = "../althea_types", features = ["actix"]}
+babel_monitor = { path = "../babel_monitor" }
 clu = { path = "../clu" }
+exit_db = { path = "../exit_db" }
 num256 = { path = "../num256" }
-ip_network = "0.1"
-log = "^0.4"
+settings = { path = "../settings" }
+
+actix = {git="https://github.com/kingoflolz/actix", branch="mocking"}
+actix-web = {git="https://github.com/kingoflolz/actix-web", default-features = false}
+actix_derive = "0.2.0"
+bytes = "0.4"
+clippy = { version = "*", optional = true }
+config = "0.8.0"
+diesel = { version = "1.0.0", features = ["sqlite"] }
+docopt = "0.8.3"
+dotenv = "0.9.0"
 env_logger = "^0.5.5"
+eui48 = {git="https://github.com/althea-mesh/eui48.git"}
+failure = "0.1.1"
+futures = "0.1"
+ip_network = "0.1"
+lazy_static = "1.0"
+log = "^0.4"
+minihttpse = "0.1.6"
+mockito = "0.9"
+mockstream = { git = "https://github.com/lazy-bitfield/rust-mockstream.git" }
+rand = "*"
+reqwest = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-reqwest = "0.8"
-rand = "*"
-lazy_static = "1.0"
-actix = {git="https://github.com/kingoflolz/actix", branch="mocking"}
-actix_derive = "0.2.0"
-config = "0.8.0"
-eui48 = {git="https://github.com/althea-mesh/eui48.git"}
-minihttpse = "0.1.6"
-docopt = "0.8.3"
-failure = "0.1.1"
-futures = "0.1"
-mockito = "0.9"
-bytes = "0.4"
 tokio = "0.1"
-actix-web = {git="https://github.com/kingoflolz/actix-web", default-features = false}
-

--- a/rita/src/rita_client/traffic_watcher/mod.rs
+++ b/rita/src/rita_client/traffic_watcher/mod.rs
@@ -12,6 +12,7 @@ use rita_common::debt_keeper::DebtKeeper;
 use num256::Int256;
 
 use std::collections::HashMap;
+use std::io::{Read, Write};
 use std::net::{IpAddr, SocketAddr, TcpStream};
 
 use ip_network::IpNetwork;
@@ -50,18 +51,22 @@ impl Handler<Watch> for TrafficWatcher {
     type Result = Result<(), Error>;
 
     fn handle(&mut self, msg: Watch, _: &mut Context<Self>) -> Self::Result {
-        let babel = TcpStream::connect::<SocketAddr>(format!(
+        let stream = TcpStream::connect::<SocketAddr>(format!(
             "[::1]:{}",
             SETTING.get_network().babel_port
         ).parse()?)?;
 
-        watch(Box::new(babel), msg.0, msg.1)
+        watch(Babel::new(stream), msg.0, msg.1)
     }
 }
 
 /// This traffic watcher watches how much traffic we send to the exit, and how much the exit sends
 /// back to us.
-pub fn watch(mut babel: Box<Babel>, exit: Identity, exit_price: u64) -> Result<(), Error> {
+pub fn watch<T: Read + Write>(
+    mut babel: Babel<T>,
+    exit: Identity,
+    exit_price: u64,
+) -> Result<(), Error> {
     babel.start_connection()?;
 
     trace!("Getting routes");
@@ -123,8 +128,25 @@ pub fn watch(mut babel: Box<Babel>, exit: Identity, exit_price: u64) -> Result<(
 
 #[cfg(test)]
 mod tests {
+    extern crate env_logger;
+
+    use super::*;
+    use althea_types::eth_address::EthAddress;
+    use std::str::FromStr;
+
     #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+    #[ignore]
+    fn debug_babel_socket_client() {
+        env_logger::init();
+        let bm_stream = TcpStream::connect::<SocketAddr>("[::1]:9001".parse().unwrap()).unwrap();
+        watch(
+            Babel::new(bm_stream),
+            Identity::new(
+                "0.0.0.0".parse().unwrap(),
+                EthAddress::from_str("abababababababababab").unwrap(),
+                String::from("abc0abc1abc2abc3abc4abc5abc6abc7abc8abc9"),
+            ),
+            5,
+        ).unwrap();
     }
 }

--- a/rita/src/rita_common/tunnel_manager/mod.rs
+++ b/rita/src/rita_common/tunnel_manager/mod.rs
@@ -351,10 +351,12 @@ impl TunnelManager {
             &mut SETTING.set_network().default_route,
         )?;
 
-        let mut babel: Box<Babel> = Box::new(TcpStream::connect::<SocketAddr>(format!(
+        let mut stream = TcpStream::connect::<SocketAddr>(format!(
             "[::1]:{}",
             SETTING.get_network().babel_port
-        ).parse()?)?);
+        ).parse()?)?;
+
+        let mut babel = Babel::new(stream);
 
         babel.start_connection()?;
         babel.monitor(&tunnel.iface_name)?;

--- a/rita/src/rita_exit/traffic_watcher/mod.rs
+++ b/rita/src/rita_exit/traffic_watcher/mod.rs
@@ -13,6 +13,7 @@ use rita_common::debt_keeper::DebtKeeper;
 use num256::Int256;
 
 use std::collections::HashMap;
+use std::io::{Read, Write};
 use std::net::{IpAddr, SocketAddr, TcpStream};
 
 use ip_network::IpNetwork;
@@ -59,17 +60,17 @@ impl Handler<Watch> for TrafficWatcher {
     type Result = Result<(), Error>;
 
     fn handle(&mut self, msg: Watch, _: &mut Context<Self>) -> Self::Result {
-        let babel = TcpStream::connect::<SocketAddr>(format!(
+        let stream = TcpStream::connect::<SocketAddr>(format!(
             "[::1]:{}",
             SETTING.get_network().babel_port
         ).parse()?)?;
 
-        watch(Box::new(babel), msg.0)
+        watch(Babel::new(stream), msg.0)
     }
 }
 
 /// This traffic watcher watches how much traffic each we send and receive from each client.
-pub fn watch(mut babel: Box<Babel>, clients: Vec<Identity>) -> Result<(), Error> {
+pub fn watch<T: Read + Write>(mut babel: Babel<T>, clients: Vec<Identity>) -> Result<(), Error> {
     babel.start_connection()?;
 
     trace!("Getting routes");
@@ -151,8 +152,15 @@ pub fn watch(mut babel: Box<Babel>, clients: Vec<Identity>) -> Result<(), Error>
 
 #[cfg(test)]
 mod tests {
+    extern crate env_logger;
+
+    use super::*;
+
     #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+    #[ignore]
+    fn debug_babel_socket_client() {
+        env_logger::init();
+        let bm_stream = TcpStream::connect::<SocketAddr>("[::1]:9001".parse().unwrap()).unwrap();
+        watch(Babel::new(bm_stream), Vec::new()).unwrap();
     }
 }


### PR DESCRIPTION
This commit fixes an issue where Babel would not work properly with a
SharedMockStream containing more than one pre-pushed babeld output,
which has to work if we want to test Babel consumers, who in turn mostly
issue more than one Babel call.

babel_monitor:
* Fix the buffering issue by moving back to a struct with BufStream
as member and flushing output on writes
* Add an error type for no terminator present in Babel output - we might
want to handle this upon stopping babeld daemons
* Verbosely inform about Babel responses

rita_client::traffic_watcher:
rita_common::traffic_watcher:
rita_exit::traffic_watcher:
* Adjust for changes in Babel
* Add an ignored test for using a localhost:9001 socket to debug the
watcher's behavior; it's got logging enabled

tunnel_manager:
* Adjust for changes in Babel