### PR TITLE
Fix positional argumnt parsing

### DIFF
--- a/integration-tests/rita.py
+++ b/integration-tests/rita.py
@@ -222,7 +222,7 @@ def start_rita(node):
     save_rita_settings(id, settings)
     time.sleep(0.1)
     os.system(
-        '(RUST_BACKTRACE=full RUST_LOG=TRACE ip netns exec netlab-{id} {rita} --config rita-settings-n{id}.toml --platform linux'
+        '(RUST_BACKTRACE=full RUST_LOG=TRACE ip netns exec netlab-{id} {rita} --config=rita-settings-n{id}.toml --platform=linux'
         ' 2>&1 & echo $! > rita-n{id}.pid) | '
         'grep -Ev "<unknown>|mio|tokio_core|hyper" > rita-n{id}.log &'.format(id=id, rita=RITA,
                                                                               pwd=dname)
@@ -240,7 +240,7 @@ def start_rita_exit(node):
     save_rita_settings(id, settings)
     time.sleep(0.1)
     os.system(
-        '(RUST_BACKTRACE=full RUST_LOG=TRACE ip netns exec netlab-{id} {rita} --config rita-settings-n{id}.toml'
+        '(RUST_BACKTRACE=full RUST_LOG=TRACE ip netns exec netlab-{id} {rita} --config=rita-settings-n{id}.toml'
         ' 2>&1 & echo $! > rita-n{id}.pid) | '
         'grep -Ev "<unknown>|mio|tokio_core|hyper" > rita-n{id}.log &'.format(id=id, rita=RITA_EXIT,
                                                                               pwd=dname)

--- a/scripts/openwrt_upload.sh
+++ b/scripts/openwrt_upload.sh
@@ -3,4 +3,4 @@ set -eux
 export ROUTER_IP=192.168.1.1
 bash scripts/openwrt_build.sh
 scp target/mipsel-unknown-linux-musl/debug/rita root@$ROUTER_IP:/tmp/rita
-ssh root@$ROUTER_IP RUST_BACKTRACE=FULL RUST_LOG=TRACE /tmp/rita --config /etc/rita.toml --platform linux &> out.log
+ssh root@$ROUTER_IP RUST_BACKTRACE=FULL RUST_LOG=TRACE /tmp/rita --config=/etc/rita.toml --platform=linux &> out.log


### PR DESCRIPTION
As outlined in this bug https://github.com/docopt/docopt.rs/issues/226
Docopt is rather specific about flags versus positional arguments. In
our case we had positional arguments that we where using as flags. This
created some very confusing behavior where you you could reorder the flags
and get a arcane looking config error because 'linux' (the platform arg)
was passed as the config arg. If you look carefully at the example USAGE
in the Docopt README https://github.com/docopt/docopt you see that all
flags not only require the Args strut but also the use of the = sign.

This patch corrects these problems and allows flags to work as expected