### PR TITLE
Add an error message for non-existent commands

### DIFF
--- a/althea_kernel_interface/src/open_tunnel.rs
+++ b/althea_kernel_interface/src/open_tunnel.rs
@@ -138,10 +138,10 @@ impl KernelInterface {
 fn test_open_tunnel_linux() {
     use KI;
 
+    use std::net::SocketAddrV6;
     use std::os::unix::process::ExitStatusExt;
     use std::process::ExitStatus;
     use std::process::Output;
-    use std::net::SocketAddrV6;
 
     let interface = String::from("wg1");
     let endpoint_link_local_ip = Ipv6Addr::new(0xfe80, 0, 0, 0x12, 0x34, 0x56, 0x78, 0x90);

--- a/althea_types/src/lib.rs
+++ b/althea_types/src/lib.rs
@@ -21,7 +21,9 @@ pub use bytes_32::Bytes32;
 pub use eth_address::EthAddress;
 pub use eth_private_key::EthPrivateKey;
 pub use eth_signature::EthSignature;
-pub use interop::{ExitClientIdentity, ExitRegistrationDetails, Identity, LocalIdentity, PaymentTx};
+pub use interop::{
+    ExitClientIdentity, ExitRegistrationDetails, Identity, LocalIdentity, PaymentTx,
+};
 
 #[cfg(test)]
 mod tests {

--- a/num256/src/lib.rs
+++ b/num256/src/lib.rs
@@ -12,7 +12,6 @@ use std::fmt;
 use std::ops::{Add, AddAssign, Deref, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use std::str::FromStr;
 
-
 #[cfg(test)]
 #[macro_use]
 extern crate serde_derive;

--- a/rita/src/rita_client/dashboard/mod.rs
+++ b/rita/src/rita_client/dashboard/mod.rs
@@ -1,4 +1,3 @@
-
 use actix::prelude::*;
 
 use failure::Error;
@@ -7,8 +6,8 @@ use futures::Future;
 use serde_json;
 use serde_json::Value;
 
-use rita_common::tunnel_manager::{GetListen, Listen, TunnelManager, UnListen};
 use rita_common::dashboard::Dashboard;
+use rita_common::tunnel_manager::{GetListen, Listen, TunnelManager, UnListen};
 use KI;
 
 pub mod network_endpoints;

--- a/rita/src/rita_client/dashboard/network_endpoints.rs
+++ b/rita/src/rita_client/dashboard/network_endpoints.rs
@@ -1,4 +1,3 @@
-
 use actix::registry::SystemService;
 use actix_web::*;
 

--- a/rita/src/rita_client/mod.rs
+++ b/rita/src/rita_client/mod.rs
@@ -1,4 +1,4 @@
+pub mod dashboard;
 pub mod exit_manager;
 pub mod rita_loop;
 pub mod traffic_watcher;
-pub mod dashboard;

--- a/rita/src/rita_common/tunnel_manager/mod.rs
+++ b/rita/src/rita_common/tunnel_manager/mod.rs
@@ -37,7 +37,6 @@ type Connector = Mocker<actors::Connector>;
 #[cfg(not(test))]
 type Connector = actors::Connector;
 
-
 #[derive(Debug, Fail)]
 pub enum TunnelManagerError {
     #[fail(display = "DNS lookup error")]

--- a/rita/src/rita_exit/rita_loop/mod.rs
+++ b/rita/src/rita_exit/rita_loop/mod.rs
@@ -90,7 +90,7 @@ impl Handler<Tick> for RitaLoop {
 
                     match exit_status {
                         Ok(_) => (),
-                        Err(e) => warn!("Error in Exit WG setup {:?}", e)
+                        Err(e) => warn!("Error in Exit WG setup {:?}", e),
                     }
 
                     ctx.notify_later(Tick {}, Duration::from_secs(5));

--- a/settings/src/lib.rs
+++ b/settings/src/lib.rs
@@ -1,10 +1,10 @@
 extern crate althea_types;
 extern crate config;
 extern crate eui48;
+extern crate failure;
 extern crate num256;
 extern crate owning_ref;
 extern crate toml;
-extern crate failure;
 
 #[macro_use]
 extern crate serde_derive;
@@ -532,7 +532,7 @@ where
 
             if old_settings != new_settings {
                 info!("writing updated config: {:?}", new_settings);
-                match settings.read().unwrap().write(&file_path){
+                match settings.read().unwrap().write(&file_path) {
                     Err(e) => warn!("writing updated config failed {:?}", e),
                     _ => (),
                 }


### PR DESCRIPTION
Normally, a failed spawn of std::process::Command would yield us an
std::io::Error with ErrorKind of NotFound. For people unfamiliar with Rust the
standard unwrap error message containing this enum variant might seem confusing.