### PR TITLE
Always write private key file

### DIFF
--- a/althea_kernel_interface/src/create_wg_key.rs
+++ b/althea_kernel_interface/src/create_wg_key.rs
@@ -9,15 +9,10 @@ use failure::Error;
 
 impl KernelInterface {
     pub fn create_wg_key(&self, path: &Path, private_key: &String) -> Result<(), Error> {
-        if path.exists() {
-            warn!("System private key exists in {:?}", path);
-            Ok(())
-        } else {
-            trace!("File does not exist, creating");
-            let mut priv_key_file = File::create(path)?;
-            write!(priv_key_file, "{}", private_key)?;
-            Ok(())
-        }
+        trace!("Overwriting old private key file");
+        let mut priv_key_file = File::create(path)?;
+        write!(priv_key_file, "{}", private_key)?;
+        Ok(())
     }
 
     pub fn create_wg_keypair(&self) -> Result<[String; 2], Error> {


### PR DESCRIPTION
This is sourced from a very frustrating debugging session in which
the /tmp/privkey no longer matched the configured privatekey. This
resulted in tunnels being setup improperly. We should consider the
configured key in the toml as the source of truth and perform a
write on each startup.