### PR TITLE
Force filesystem consistency after edits

### DIFF
--- a/althea_kernel_interface/src/fs_sync.rs
+++ b/althea_kernel_interface/src/fs_sync.rs
@@ -1,0 +1,12 @@
+use super::KernelInterface;
+use failure::Error;
+
+impl KernelInterface {
+    /// Performs a full filesystem sync by running the sync command.
+    /// If there are any outstanding writes they will be flushed to the disk
+    /// Currently used because UBIFS devices seem to have issues
+    pub fn fs_sync(&self) -> Result<(), Error> {
+        self.run_command("sync", &[])?;
+        Ok(())
+    }
+}

--- a/althea_kernel_interface/src/lib.rs
+++ b/althea_kernel_interface/src/lib.rs
@@ -24,6 +24,7 @@ mod exit_client_counter;
 mod exit_client_tunnel;
 mod exit_server_counter;
 mod exit_server_tunnel;
+mod fs_sync;
 mod get_neighbors;
 mod interface_tools;
 mod ip_route;

--- a/rita/src/rita_client/dashboard/mod.rs
+++ b/rita/src/rita_client/dashboard/mod.rs
@@ -150,6 +150,9 @@ impl Handler<SetWifiConfig> for Dashboard {
         KI.uci_commit()?;
         KI.openwrt_reset_wireless()?;
 
+        // We edited disk contents, force global sync
+        KI.fs_sync()?;
+
         Ok(())
     }
 }

--- a/settings/Cargo.toml
+++ b/settings/Cargo.toml
@@ -16,3 +16,4 @@ toml = "0.4.5"
 log = "^0.4"
 failure = "0.1.1"
 owning_ref = {git="https://github.com/kingoflolz/owning-ref-rs/", branch="fix-bug"}
+lazy_static = "1.0"


### PR DESCRIPTION
This is a test commit for the EdgerouterX, I'm not sure if it's overkill though. In theory anything that edits files should call for a sync of that file, but on the ERX it seems that it's not happening in specific situations. This fixes that, but is it the best way to do it?