### PR TITLE
Fix deserialization of ExitState type

### DIFF
--- a/althea_types/src/interop.rs
+++ b/althea_types/src/interop.rs
@@ -1,5 +1,8 @@
 use eth_address::EthAddress;
 use num256::Uint256;
+use serde;
+use serde::Deserialize;
+use serde::Deserializer;
 use std::net::IpAddr;
 
 #[cfg(feature = "actix")]
@@ -45,6 +48,33 @@ pub enum ExitState {
     Registered,
     Denied,
     Disabled,
+}
+
+pub trait DeserializeWith: Sized {
+    fn deserialize_with<'de, D>(de: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>;
+}
+
+impl DeserializeWith for ExitState {
+    fn deserialize_with<'de, D>(de: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(de)?;
+
+        match s.as_ref() {
+            "New" => Ok(ExitState::New),
+            "GotInto" => Ok(ExitState::GotInfo),
+            "Pending" => Ok(ExitState::Pending),
+            "Registered" => Ok(ExitState::Registered),
+            "Denied" => Ok(ExitState::Denied),
+            "Disabled" => Ok(ExitState::Disabled),
+            _ => Err(serde::de::Error::custom(
+                "error trying to deserialize rotation policy config",
+            )),
+        }
+    }
 }
 
 impl Default for ExitState {

--- a/settings/src/lib.rs
+++ b/settings/src/lib.rs
@@ -30,7 +30,8 @@ use std::time::Duration;
 use config::Config;
 
 use althea_types::{
-    EthAddress, ExitClientDetails, ExitDetails, ExitRegistrationDetails, ExitState, Identity,
+    DeserializeWith, EthAddress, ExitClientDetails, ExitDetails, ExitRegistrationDetails,
+    ExitState, Identity,
 };
 
 use num256::Int256;
@@ -109,7 +110,7 @@ pub struct ExitServer {
     pub our_details: Option<ExitClientDetails>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub general_details: Option<ExitDetails>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "ExitState::deserialize_with")]
     pub state: ExitState,
     #[serde(default)]
     pub message: String,


### PR DESCRIPTION
Previously you could generate and save the Enum using serde but not
deserialize it, this corrects that issue.