### PR TITLE
Fix neighbors http

### DIFF
--- a/api-docs/router-dashboard/get-neighbors.md
+++ b/api-docs/router-dashboard/get-neighbors.md
@@ -18,20 +18,20 @@ GET
 
 ```
 [
-   	{
-   		"nickname": "fd00::2",
-   		"route_metric_to_exit": 0,
-   		"total_debt": 0,
-   		"current_debt": 0,
-         "link_cost": 0
-   	},
-   	{
-   		"nickname": "fd00::7",
-   		"route_metric_to_exit": 0,
-   		"total_debt": 0,
-   		"current_debt": 0,
-         "link_cost": 0
-   	}
+   {
+      "nickname": "fd00::2",
+      "route_metric_to_exit": 0,
+      "total_debt": 0,
+      "current_debt": 0,
+      "link_cost": 0
+   },
+   {
+      "nickname": "fd00::7",
+      "route_metric_to_exit": 0,
+      "total_debt": 0,
+      "current_debt": 0,
+      "link_cost": 0
+   }
 ]
 ```
 

--- a/api-docs/router-dashboard/get-neighbors.md
+++ b/api-docs/router-dashboard/get-neighbors.md
@@ -17,18 +17,20 @@ GET
 ### Content
 
 ```
-   [
+[
    	{
    		"nickname": "fd00::2",
    		"route_metric_to_exit": 0,
-   		"total_payments": 0,
-   		"debt": 0
+   		"total_debt": 0,
+   		"current_debt": 0,
+         "link_cost": 0
    	},
    	{
    		"nickname": "fd00::7",
    		"route_metric_to_exit": 0,
-   		"total_payments": 0,
-   		"debt": 0
+   		"total_debt": 0,
+   		"current_debt": 0,
+         "link_cost": 0
    	}
 ]
 ```

--- a/api-docs/router-dashboard/get-neighbors.md
+++ b/api-docs/router-dashboard/get-neighbors.md
@@ -23,14 +23,16 @@ GET
       "route_metric_to_exit": 0,
       "total_debt": 0,
       "current_debt": 0,
-      "link_cost": 0
+      "link_cost": 0,
+      "price_to_exit": 0
    },
    {
       "nickname": "fd00::7",
       "route_metric_to_exit": 0,
       "total_debt": 0,
       "current_debt": 0,
-      "link_cost": 0
+      "link_cost": 0,
+      "price_to_exit": 0
    }
 ]
 ```


### PR DESCRIPTION
There were some misnamed and missing fields in the http response for /neighbors. The dashboard will not work until these are fixed. I've added the "link_cost" field, I assume this information is easily available from babel. 

Sorry about renaming. These field names were documented in the althea-dash repo, but not clearly. We also discussed them in chat, but that got lost. Hopefully with this new documentation folder we will be able to keep stuff straight.