### PR TITLE
Fix neighbors http

### DIFF
--- a/api-docs/router-dashboard/get-neighbors.md
+++ b/api-docs/router-dashboard/get-neighbors.md
@@ -18,20 +18,20 @@ GET
 
 ```
 [
-   	{
-   		"nickname": "fd00::2",
-   		"route_metric_to_exit": 0,
-   		"total_debt": 0,
-   		"current_debt": 0,
-         "link_cost": 0
-   	},
-   	{
-   		"nickname": "fd00::7",
-   		"route_metric_to_exit": 0,
-   		"total_debt": 0,
-   		"current_debt": 0,
-         "link_cost": 0
-   	}
+   {
+      "nickname": "fd00::2",
+      "route_metric_to_exit": 0,
+      "total_debt": 0,
+      "current_debt": 0,
+      "link_cost": 0
+   },
+   {
+      "nickname": "fd00::7",
+      "route_metric_to_exit": 0,
+      "total_debt": 0,
+      "current_debt": 0,
+      "link_cost": 0
+   }
 ]
 ```
 

--- a/api-docs/router-dashboard/get-neighbors.md
+++ b/api-docs/router-dashboard/get-neighbors.md
@@ -17,18 +17,20 @@ GET
 ### Content
 
 ```
-   [
+[
    	{
    		"nickname": "fd00::2",
    		"route_metric_to_exit": 0,
-   		"total_payments": 0,
-   		"debt": 0
+   		"total_debt": 0,
+   		"current_debt": 0,
+         "link_cost": 0
    	},
    	{
    		"nickname": "fd00::7",
    		"route_metric_to_exit": 0,
-   		"total_payments": 0,
-   		"debt": 0
+   		"total_debt": 0,
+   		"current_debt": 0,
+         "link_cost": 0
    	}
 ]
 ```

--- a/api-docs/router-dashboard/get-neighbors.md
+++ b/api-docs/router-dashboard/get-neighbors.md
@@ -23,14 +23,16 @@ GET
       "route_metric_to_exit": 0,
       "total_debt": 0,
       "current_debt": 0,
-      "link_cost": 0
+      "link_cost": 0,
+      "price_to_exit": 0
    },
    {
       "nickname": "fd00::7",
       "route_metric_to_exit": 0,
       "total_debt": 0,
       "current_debt": 0,
-      "link_cost": 0
+      "link_cost": 0,
+      "price_to_exit": 0
    }
 ]
 ```

--- a/rita/src/exit.rs
+++ b/rita/src/exit.rs
@@ -189,7 +189,6 @@ fn main() {
             // assuming exit nodes dont need wifi
             //.resource("/wifisettings", |r| r.route().filter(pred::Get()).h(get_wifi_config))
             //.resource("/wifisettings", |r| r.route().filter(pred::Post()).h(set_wifi_config))
-            .route("/neighbors", Method::GET, get_node_info)
             .route("/info", Method::GET, get_own_info)
             .route("/settings", Method::GET, get_settings)
             .route("/settings", Method::POST, set_settings)

--- a/rita/src/rita_client/dashboard/network_endpoints.rs
+++ b/rita/src/rita_client/dashboard/network_endpoints.rs
@@ -5,7 +5,7 @@ use futures::Future;
 
 use std::boxed::Box;
 
-use super::{Dashboard, GetWifiConfig, SetWifiConfig};
+use super::{Dashboard, GetNodeInfo, GetWifiConfig, NodeInfo, SetWifiConfig};
 use rita_client::dashboard::WifiInterface;
 
 pub fn get_wifi_config(
@@ -28,6 +28,14 @@ pub fn set_wifi_config(
 
     Dashboard::from_registry()
         .send(SetWifiConfig(new_settings_vec))
+        .from_err()
+        .and_then(move |reply| Ok(Json(reply?)))
+        .responder()
+}
+
+pub fn get_node_info(_req: HttpRequest) -> Box<Future<Item = Json<Vec<NodeInfo>>, Error = Error>> {
+    Dashboard::from_registry()
+        .send(GetNodeInfo {})
         .from_err()
         .and_then(move |reply| Ok(Json(reply?)))
         .responder()

--- a/rita/src/rita_common/dashboard/mod.rs
+++ b/rita/src/rita_common/dashboard/mod.rs
@@ -1,11 +1,8 @@
 use actix::prelude::*;
 
 use failure::Error;
-use futures;
 use futures::Future;
-use serde_json;
 
-use rita_common::debt_keeper::{DebtKeeper, Dump};
 use rita_common::payment_controller::{GetOwnBalance, PaymentController};
 
 pub mod network_endpoints;
@@ -26,48 +23,6 @@ impl SystemService for Dashboard {
 impl Default for Dashboard {
     fn default() -> Dashboard {
         Dashboard {}
-    }
-}
-
-#[derive(Serialize)]
-pub struct NodeInfo {
-    pub nickname: String,
-    pub route_metric_to_exit: u64,
-    pub total_payments: i64,
-    pub debt: i64,
-}
-
-pub struct GetNodeInfo;
-
-impl Message for GetNodeInfo {
-    type Result = Result<Vec<NodeInfo>, Error>;
-}
-
-impl Handler<GetNodeInfo> for Dashboard {
-    type Result = ResponseFuture<Vec<NodeInfo>, Error>;
-
-    fn handle(&mut self, _msg: GetNodeInfo, _ctx: &mut Self::Context) -> Self::Result {
-        Box::new(
-            DebtKeeper::from_registry()
-                .send(Dump {})
-                .and_then(|res| {
-                    let res = res.unwrap();
-
-                    let mut output = Vec::new();
-
-                    for (k, v) in res.iter() {
-                        output.push(NodeInfo {
-                            nickname: serde_json::to_string(&k.mesh_ip).unwrap(),
-                            route_metric_to_exit: 0,
-                            total_payments: v.total_payment_recieved.clone().into(),
-                            debt: v.debt.clone().into(),
-                        })
-                    }
-
-                    futures::future::ok(output)
-                })
-                .from_err(),
-        )
     }
 }
 

--- a/rita/src/rita_common/dashboard/network_endpoints.rs
+++ b/rita/src/rita_common/dashboard/network_endpoints.rs
@@ -10,18 +10,9 @@ use serde_json;
 use settings::RitaCommonSettings;
 use SETTING;
 
-use super::{Dashboard, GetOwnInfo, NodeInfo, OwnInfo};
+use super::{Dashboard, GetOwnInfo, OwnInfo};
 
-use rita_common::dashboard::GetNodeInfo;
 use rita_common::network_endpoints::JsonStatusResponse;
-
-pub fn get_node_info(_req: HttpRequest) -> Box<Future<Item = Json<Vec<NodeInfo>>, Error = Error>> {
-    Dashboard::from_registry()
-        .send(GetNodeInfo {})
-        .from_err()
-        .and_then(move |reply| Ok(Json(reply?)))
-        .responder()
-}
 
 pub fn get_own_info(_req: HttpRequest) -> Box<Future<Item = Json<OwnInfo>, Error = Error>> {
     Dashboard::from_registry()


### PR DESCRIPTION
Taken from #100 implements the plumbing for Babel to query neighbours. Disables a lot of the breaking rtt stuff that @drozdziak1 is probably working on in #97 

I need to talk with @drozdziak1 and confirm a few things about our babel interface. 

Also I'm starting to speculate that our endpoints are very variable in response time (between .2 seconds and several seconds) because we have a single thread that may be blocked by various tasks. 