### PR TITLE
Only ping interfaces configured for peer discovery

### DIFF
--- a/althea_kernel_interface/src/get_neighbors.rs
+++ b/althea_kernel_interface/src/get_neighbors.rs
@@ -1,5 +1,6 @@
 use super::KernelInterface;
 
+use std::collections::HashSet;
 use std::net::IpAddr;
 use std::str::FromStr;
 
@@ -25,8 +26,8 @@ impl KernelInterface {
         Ok(vec)
     }
 
-    pub fn trigger_neighbor_disc(&self) -> Result<(), Error> {
-        for interface in self.get_interfaces()? {
+    pub fn trigger_neighbor_disc(&self, interfaces: &HashSet<String>) -> Result<(), Error> {
+        for interface in interfaces.iter() {
             self.run_command("ping6", &["-c1", "-I", &interface, "ff02::1"])?;
         }
         Ok(())

--- a/scripts/bridge.sh
+++ b/scripts/bridge.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # this bridges a router into the integration test mesh
 
-ip link set enx000ec6a0b495 netns netlab-1
-ip netns exec netlab-1 ifconfig enx000ec6a0b495 up
+# ip link set enx000ec6a0b495 netns netlab-1
+# ip netns exec netlab-1 ifconfig enx000ec6a0b495 up
 
 ifconfig enx001cc2330150 down
 dhclient enx001cc2330150


### PR DESCRIPTION
It's wasteful to ping all interfaces and then remove entries we don't
need.

supersedes #115 