### PR TITLE
fix exit geoip

### DIFF
--- a/rita/src/rita_client/exit_manager/mod.rs
+++ b/rita/src/rita_client/exit_manager/mod.rs
@@ -104,9 +104,14 @@ fn exit_setup_request(exit: &String) -> Result<(), Error> {
 
     trace!("Got exit setup response {:?}", exit_response.clone());
 
-    current_exit.our_details = Some(ExitClientDetails {
-        client_internal_ip: exit_response.details.unwrap().client_internal_ip,
-    });
+    match exit_response.details {
+        Some(details) => {
+            current_exit.our_details = Some(ExitClientDetails {
+                client_internal_ip: details.client_internal_ip,
+            });
+        }
+        None => bail!("Got no details from exit"),
+    }
 
     Ok(())
 }

--- a/rita/src/rita_exit/db_client/mod.rs
+++ b/rita/src/rita_exit/db_client/mod.rs
@@ -18,12 +18,6 @@ use failure::Error;
 
 use althea_types::{ExitClientIdentity, ExitRegistrationDetails};
 
-#[derive(Debug, Fail)]
-pub enum DBClientError {
-    #[fail(display = "Identify verification error")]
-    IdentityVerificationError,
-}
-
 #[derive(Default)]
 pub struct DbClient;
 
@@ -129,106 +123,107 @@ impl Handler<SetupClient> for DbClient {
         use self::schema::clients::dsl::*;
         let conn = SqliteConnection::establish(&SETTING.get_db_file()).unwrap();
 
-        if let Ok(_) = verify_identity(&msg.0.reg_details, &msg.1) {
-            let client = msg.0;
+        match verify_identity(&msg.0.reg_details, &msg.1) {
+            Ok(_) => {
+                let client = msg.0;
 
-            conn.transaction::<_, Error, _>(|| {
-                let dummy = models::Client {
-                    mesh_ip: "0.0.0.0".to_string(),
-                    wg_pubkey: "".to_string(),
-                    wg_port: "".to_string(),
-                    luci_pass: "".to_string(),
-                    internal_ip: SETTING.get_exit_network().exit_start_ip.to_string(),
-                    email: "".to_string(),
-                    zip: "".to_string(),
-                    country: "".to_string(),
-                };
-
-                match diesel::insert_into(clients).values(&dummy).execute(&conn) {
-                    Err(e) => warn!("got error inserting dummy: {}", e),
-                    _ => {}
-                }
-
-                trace!("Checking if record exists for {:?}", client.global.mesh_ip);
-
-                let exists = select(exists(
-                    clients.filter(mesh_ip.eq(&client.global.mesh_ip.to_string())),
-                )).get_result(&conn)
-                    .expect("Error loading statuses");
-
-                if exists {
-                    trace!("record exists, updating");
-                    // updating
-                    diesel::update(clients.find(&client.global.mesh_ip.to_string()))
-                        .set(wg_port.eq(&client.wg_port.to_string()))
-                        .execute(&conn)
-                        .expect("Error saving");
-
-                    diesel::update(clients.find(&client.global.mesh_ip.to_string()))
-                        .set(wg_pubkey.eq(&client.global.wg_public_key.clone()))
-                        .execute(&conn)
-                        .expect("Error saving");
-
-                    diesel::update(clients.find(&client.global.mesh_ip.to_string()))
-                        .set(email.eq(&client.reg_details.email.clone().unwrap()))
-                        .execute(&conn)
-                        .expect("Error saving");
-
-                    diesel::update(clients.find(&client.global.mesh_ip.to_string()))
-                        .set(zip.eq(&client.reg_details.zip_code.clone().unwrap()))
-                        .execute(&conn)
-                        .expect("Error saving");
-
-                    let their_record: models::Client = clients
-                        .filter(mesh_ip.eq(&client.global.mesh_ip.to_string()))
-                        .load::<models::Client>(&conn)
-                        .expect("failed loading record")[0]
-                        .clone();
-
-                    Ok(their_record.internal_ip.parse()?)
-                } else {
-                    trace!("record does not exist, creating");
-                    // first time seeing
-
-                    let dummy: models::Client = clients
-                        .filter(mesh_ip.eq("0.0.0.0"))
-                        .load::<models::Client>(&conn)
-                        .expect("failed loading dummy")[0]
-                        .clone();
-
-                    trace!("dummy: {:?}", dummy);
-
-                    let new_ip = increment(dummy.internal_ip.parse().unwrap()).unwrap();
-
-                    diesel::update(clients.filter(mesh_ip.eq("0.0.0.0")))
-                        .set(internal_ip.eq(&new_ip.to_string()))
-                        .execute(&conn)
-                        .expect("Error saving dummy");
-
-                    let c = models::Client {
-                        luci_pass: "".into(),
-                        wg_port: client.wg_port.to_string(),
-                        mesh_ip: client.global.mesh_ip.to_string(),
-                        wg_pubkey: client.global.wg_public_key.clone(),
-                        internal_ip: new_ip.to_string(),
-                        email: client.reg_details.email.clone().unwrap_or("".to_string()),
-                        zip: client
-                            .reg_details
-                            .zip_code
-                            .clone()
-                            .unwrap_or("".to_string()),
-                        country: client.reg_details.country.clone().unwrap_or("".to_string()),
+                conn.transaction::<_, Error, _>(|| {
+                    let dummy = models::Client {
+                        mesh_ip: "0.0.0.0".to_string(),
+                        wg_pubkey: "".to_string(),
+                        wg_port: "".to_string(),
+                        luci_pass: "".to_string(),
+                        internal_ip: SETTING.get_exit_network().exit_start_ip.to_string(),
+                        email: "".to_string(),
+                        zip: "".to_string(),
+                        country: "".to_string(),
                     };
 
-                    diesel::insert_into(clients)
-                        .values(&c)
-                        .execute(&conn)
-                        .expect("Error saving");
-                    Ok(new_ip)
-                }
-            })
-        } else {
-            Err(DBClientError::IdentityVerificationError.into())
+                    match diesel::insert_into(clients).values(&dummy).execute(&conn) {
+                        Err(e) => warn!("got error inserting dummy: {}", e),
+                        _ => {}
+                    }
+
+                    trace!("Checking if record exists for {:?}", client.global.mesh_ip);
+
+                    let exists = select(exists(
+                        clients.filter(mesh_ip.eq(&client.global.mesh_ip.to_string())),
+                    )).get_result(&conn)
+                        .expect("Error loading statuses");
+
+                    if exists {
+                        trace!("record exists, updating");
+                        // updating
+                        diesel::update(clients.find(&client.global.mesh_ip.to_string()))
+                            .set(wg_port.eq(&client.wg_port.to_string()))
+                            .execute(&conn)
+                            .expect("Error saving");
+
+                        diesel::update(clients.find(&client.global.mesh_ip.to_string()))
+                            .set(wg_pubkey.eq(&client.global.wg_public_key.clone()))
+                            .execute(&conn)
+                            .expect("Error saving");
+
+                        diesel::update(clients.find(&client.global.mesh_ip.to_string()))
+                            .set(email.eq(&client.reg_details.email.clone().unwrap()))
+                            .execute(&conn)
+                            .expect("Error saving");
+
+                        diesel::update(clients.find(&client.global.mesh_ip.to_string()))
+                            .set(zip.eq(&client.reg_details.zip_code.clone().unwrap()))
+                            .execute(&conn)
+                            .expect("Error saving");
+
+                        let their_record: models::Client = clients
+                            .filter(mesh_ip.eq(&client.global.mesh_ip.to_string()))
+                            .load::<models::Client>(&conn)
+                            .expect("failed loading record")[0]
+                            .clone();
+
+                        Ok(their_record.internal_ip.parse()?)
+                    } else {
+                        trace!("record does not exist, creating");
+                        // first time seeing
+
+                        let dummy: models::Client = clients
+                            .filter(mesh_ip.eq("0.0.0.0"))
+                            .load::<models::Client>(&conn)
+                            .expect("failed loading dummy")[0]
+                            .clone();
+
+                        trace!("dummy: {:?}", dummy);
+
+                        let new_ip = increment(dummy.internal_ip.parse().unwrap()).unwrap();
+
+                        diesel::update(clients.filter(mesh_ip.eq("0.0.0.0")))
+                            .set(internal_ip.eq(&new_ip.to_string()))
+                            .execute(&conn)
+                            .expect("Error saving dummy");
+
+                        let c = models::Client {
+                            luci_pass: "".into(),
+                            wg_port: client.wg_port.to_string(),
+                            mesh_ip: client.global.mesh_ip.to_string(),
+                            wg_pubkey: client.global.wg_public_key.clone(),
+                            internal_ip: new_ip.to_string(),
+                            email: client.reg_details.email.clone().unwrap_or("".to_string()),
+                            zip: client
+                                .reg_details
+                                .zip_code
+                                .clone()
+                                .unwrap_or("".to_string()),
+                            country: client.reg_details.country.clone().unwrap_or("".to_string()),
+                        };
+
+                        diesel::insert_into(clients)
+                            .values(&c)
+                            .execute(&conn)
+                            .expect("Error saving");
+                        Ok(new_ip)
+                    }
+                })
+            }
+            Err(e) => return Err(e),
         }
     }
 }


### PR DESCRIPTION
fix exit geoip by stopping rita from crashing when it strays off the happy path (request did not succeed) and return more descriptive errors to the client