### PR TITLE
Add script for statically building desktop binaries

### DIFF
--- a/rita/Cargo.toml
+++ b/rita/Cargo.toml
@@ -32,6 +32,7 @@ bytes = "0.4"
 clippy = { version = "*", optional = true }
 config = "0.8.0"
 diesel = { version = "=1.2.0", features = ["sqlite"] }
+libsqlite3-sys = { version = "*", features = ["bundled"] }
 docopt = "0.8.3"
 dotenv = "0.9.0"
 env_logger = "^0.5.5"

--- a/scripts/linux_build_static.sh
+++ b/scripts/linux_build_static.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# You may need to disable or modify selinux
+set -eux
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+BUILDER="docker run --rm -it -v $(pwd):/home/rust/src ekidd/rust-musl-builder"
+pushd $DIR
+cargo clean
+$BUILDER cargo build --all --release


### PR DESCRIPTION
This script allows us to build rita and rita_exit binaries for
linux desktops on x86 that are totally static. No more compiling
on a dinky little VM just to get Centos dynamic lib compatiblity.

The big trick here is using the rust musl builder docker container
tried using pure openwrt but it turns out you also need to build
rustc itself against musl for that to work. 