### PR TITLE
Correct default exit ip range

### DIFF
--- a/settings/src/lib.rs
+++ b/settings/src/lib.rs
@@ -291,9 +291,9 @@ impl Default for ExitNetworkSettings {
             exit_hello_port: 4875,
             wg_tunnel_port: 59999,
             exit_price: 10,
-            own_internal_ip: "172.168.1.254".parse().unwrap(),
-            exit_start_ip: "172.168.1.100".parse().unwrap(),
-            netmask: 24,
+            own_internal_ip: "172.16.255.254".parse().unwrap(),
+            exit_start_ip: "172.16.0.0".parse().unwrap(),
+            netmask: 12,
         }
     }
 }


### PR DESCRIPTION
So the 172 range is 16 not 168 for the private section. We're lucky
this doesn't seem to break many sites because the block is assigned
to AOL and presumably used for Dialup users.

This also expands the assignment range to the maximum allowed, which
is more than a million people on a single exit server, not somthing
I ever expect to see.