### PR TITLE
Add exits endpoint for liveness

### DIFF
--- a/althea_kernel_interface/src/lib.rs
+++ b/althea_kernel_interface/src/lib.rs
@@ -33,6 +33,7 @@ mod link_local_tools;
 mod manipulate_uci;
 mod open_tunnel;
 mod openwrt_ubus;
+mod ping_check;
 mod setup_wg_if;
 mod stats;
 mod wireless;

--- a/althea_kernel_interface/src/ping_check.rs
+++ b/althea_kernel_interface/src/ping_check.rs
@@ -1,0 +1,16 @@
+use super::KernelInterface;
+use failure::Error;
+use std::net::IpAddr;
+
+impl KernelInterface {
+    //Pings a ipv6 address to determine if it's online
+    pub fn ping_check_v6(&self, ip: &IpAddr) -> Result<bool, Error> {
+        let result = self.run_command("ping6", &["-w1", "-W1", "-c1", &ip.to_string()]);
+        Ok(result?.status.success())
+    }
+    //Pings a ipv4 address to determine if it's online
+    pub fn ping_check_v4(&self, ip: &IpAddr) -> Result<bool, Error> {
+        let result = self.run_command("ping", &["-w1", "-W1", "-c1", &ip.to_string()]);
+        Ok(result?.status.success())
+    }
+}

--- a/docs/api/router-dashboard.md
+++ b/docs/api/router-dashboard.md
@@ -66,6 +66,47 @@ This file documents the dashboard API found in Rita client.
 
 ---
 
+## /exits
+
+- URL: `<rita ip>:<rita_dashboard_port>/exits'
+- Method: `GET`
+- URL Params: `None`
+- Data Params: `None`
+- Success Response:
+  - Code: 200 OK
+  - Contents:
+
+```
+[
+   {
+      "nickname": "apac",
+      "exit_settings": {
+        "id": {
+          "eth_address": "0x0101010101010101010101010101010101010101",
+          "mesh_ip": "fd96::1337:e4f",
+          "wg_public_key": "1kKSpzdhI4kfqeMqch9I1bXqOUXeKN7EQBecVzW60ys="
+        },
+        "message": "In Singapore",
+        "registration_port": 4875,
+        "state": "New"
+      }
+      "is_selected": true,
+      "have_route": true,
+      "is_reachable": true,
+      "is_tunnel_working": true,
+   },
+]
+```
+
+- Error Response: `500 Server Error`
+
+- Sample Call:
+
+`curl 127.0.0.1:4877/exits`
+
+---
+
+
 ## /settings
 
 - URL: `<rita ip>:<rita_dashboard_port>/settings`

--- a/rita/src/client.rs
+++ b/rita/src/client.rs
@@ -185,6 +185,7 @@ fn main() {
             .route("/settings", Method::GET, get_settings)
             .route("/settings", Method::POST, set_settings)
             .route("/neighbors", Method::GET, get_node_info)
+            .route("/exits", Method::GET, get_exit_info)
             .route("/info", Method::GET, get_own_info)
             .route("/version", Method::GET, version)
     }).workers(1)

--- a/rita/src/rita_client/dashboard/network_endpoints.rs
+++ b/rita/src/rita_client/dashboard/network_endpoints.rs
@@ -5,7 +5,9 @@ use futures::Future;
 
 use std::boxed::Box;
 
-use super::{Dashboard, GetNodeInfo, GetWifiConfig, NodeInfo, SetWifiConfig};
+use super::{
+    Dashboard, ExitInfo, GetExitInfo, GetNodeInfo, GetWifiConfig, NodeInfo, SetWifiConfig,
+};
 use rita_client::dashboard::WifiInterface;
 
 pub fn get_wifi_config(
@@ -36,6 +38,14 @@ pub fn set_wifi_config(
 pub fn get_node_info(_req: HttpRequest) -> Box<Future<Item = Json<Vec<NodeInfo>>, Error = Error>> {
     Dashboard::from_registry()
         .send(GetNodeInfo {})
+        .from_err()
+        .and_then(move |reply| Ok(Json(reply?)))
+        .responder()
+}
+
+pub fn get_exit_info(_req: HttpRequest) -> Box<Future<Item = Json<Vec<ExitInfo>>, Error = Error>> {
+    Dashboard::from_registry()
+        .send(GetExitInfo {})
         .from_err()
         .and_then(move |reply| Ok(Json(reply?)))
         .responder()

--- a/rita/src/rita_client/dashboard/network_endpoints.rs
+++ b/rita/src/rita_client/dashboard/network_endpoints.rs
@@ -13,6 +13,7 @@ use rita_client::dashboard::WifiInterface;
 pub fn get_wifi_config(
     _req: HttpRequest,
 ) -> Box<Future<Item = Json<Vec<WifiInterface>>, Error = Error>> {
+    debug!("Get wificonfig hit!");
     Dashboard::from_registry()
         .send(GetWifiConfig {})
         .from_err()
@@ -23,6 +24,7 @@ pub fn get_wifi_config(
 pub fn set_wifi_config(
     new_settings: Json<WifiInterface>,
 ) -> Box<Future<Item = Json<()>, Error = Error>> {
+    debug!("Set wificonfig endpoint hit!");
     //This will be dead code if the JS is modified to submit both interfaces
     //in one vector
     let mut new_settings_vec = Vec::new();
@@ -36,6 +38,7 @@ pub fn set_wifi_config(
 }
 
 pub fn get_node_info(_req: HttpRequest) -> Box<Future<Item = Json<Vec<NodeInfo>>, Error = Error>> {
+    debug!("Neighbors endpoint hit!");
     Dashboard::from_registry()
         .send(GetNodeInfo {})
         .from_err()
@@ -44,6 +47,7 @@ pub fn get_node_info(_req: HttpRequest) -> Box<Future<Item = Json<Vec<NodeInfo>>
 }
 
 pub fn get_exit_info(_req: HttpRequest) -> Box<Future<Item = Json<Vec<ExitInfo>>, Error = Error>> {
+    debug!("Exit endpoint hit!");
     Dashboard::from_registry()
         .send(GetExitInfo {})
         .from_err()

--- a/rita/src/rita_common/dashboard/network_endpoints.rs
+++ b/rita/src/rita_common/dashboard/network_endpoints.rs
@@ -15,6 +15,7 @@ use super::{Dashboard, GetOwnInfo, OwnInfo};
 use rita_common::network_endpoints::JsonStatusResponse;
 
 pub fn get_own_info(_req: HttpRequest) -> Box<Future<Item = Json<OwnInfo>, Error = Error>> {
+    debug!("Get own info endpoint hit!");
     Dashboard::from_registry()
         .send(GetOwnInfo {})
         .from_err()
@@ -23,12 +24,14 @@ pub fn get_own_info(_req: HttpRequest) -> Box<Future<Item = Json<OwnInfo>, Error
 }
 
 pub fn get_settings(_req: HttpRequest) -> Result<Json<serde_json::Value>, Error> {
+    debug!("Get settings endpoint hit!");
     Ok(Json(SETTING.get_all()?))
 }
 
 pub fn set_settings(
     new_settings: Json<serde_json::Value>,
 ) -> Result<Json<JsonStatusResponse>, Error> {
+    debug!("Set settings endpoint hit!");
     SETTING.merge(new_settings.into_inner())?;
 
     JsonStatusResponse::new(Ok("New settings applied".to_string()))


### PR DESCRIPTION
The new exit's endpoint is somewhat redundant compared to the settings endpoint
but provides liveness info like the reachability and tunnel state.