### PR TITLE
Parsing of alpha3 style hellos removed too early

### DIFF
--- a/rita/src/rita_common/http_client/mod.rs
+++ b/rita/src/rita_common/http_client/mod.rs
@@ -10,6 +10,9 @@ use futures::Future;
 
 use althea_types::{ExitClientIdentity, ExitDetails, ExitServerReply, Identity, LocalIdentity};
 
+use settings::RitaCommonSettings;
+use SETTING;
+
 use actix_web::client::Connection;
 use failure::Error;
 
@@ -52,7 +55,15 @@ impl Handler<Hello> for HTTPClient {
 
             let req = req.with_connection(Connection::from_stream(stream));
 
-            let req = req.json(&msg.my_id);
+            let req = if SETTING.get_future() {
+                req.json(&msg.my_id)
+            } else {
+                // TODO: REMOVE IN ALPHA 6
+                req.json(LocalIdentity {
+                    global: msg.my_id.clone(),
+                    wg_port: 12345,
+                })
+            };
 
             req.unwrap().send().from_err().and_then(|response| {
                 response


### PR DESCRIPTION
So alpha3 has what we wanted to change, alpha4 has both new and old
support but by default it sends old packets. Alpha5 needs to move
the default to the new packets but keep support for hearing the old
stuff. Then in Alpha6 the change is finally totally done. In the future
we should be more careful to mark these correctly. And/or insitute a
transition date so that the Alpha4 releases moved to future on their own