### PR TITLE
Allow WAN toggle during operation

### DIFF
--- a/rita/src/client.rs
+++ b/rita/src/client.rs
@@ -1,4 +1,7 @@
-#![cfg_attr(feature = "system_alloc", feature(alloc_system, allocator_api))]
+#![cfg_attr(
+    feature = "system_alloc",
+    feature(alloc_system, allocator_api)
+)]
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 

--- a/rita/src/exit.rs
+++ b/rita/src/exit.rs
@@ -1,4 +1,7 @@
-#![cfg_attr(feature = "system_alloc", feature(alloc_system, allocator_api))]
+#![cfg_attr(
+    feature = "system_alloc",
+    feature(alloc_system, allocator_api)
+)]
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 

--- a/rita/src/rita_common/traffic_watcher/mod.rs
+++ b/rita/src/rita_common/traffic_watcher/mod.rs
@@ -219,6 +219,7 @@ pub fn watch<T: Read + Write>(
         _ => false,
     };
 
+    trace!("We are a Gateway: {}", gateway);
     SETTING.get_network_mut().is_gateway = gateway;
 
     Ok(())


### PR DESCRIPTION
Previously per hop tunnels for gateways would only operate properly
when you started Rita with the machine in a totally ready state.
Now per hop gateways are reactive and will open at any time when
a device gets a default route on the external_nic. This should
solve several hard to debug issues.