### PR TITLE
Fix recent formatting issues.

### DIFF
--- a/althea_kernel_interface/src/interface_tools.rs
+++ b/althea_kernel_interface/src/interface_tools.rs
@@ -123,8 +123,7 @@ fn test_get_wg_remote_ip() {
         assert_eq!(args, &["show", "wg0", "endpoints"]);
         Ok(Output {
             stdout: b"fvLYbeMV+RYbzJEc4lNEPuK8ulva/5wcSJBz0W5t3hM=	71.8.186.226:60000\
-"
-                .to_vec(),
+".to_vec(),
             stderr: b"".to_vec(),
             status: ExitStatus::from_raw(0),
         })

--- a/rita/src/client.rs
+++ b/rita/src/client.rs
@@ -189,10 +189,10 @@ fn main() {
             r.method(Method::POST).with(make_payments)
         })
     }).workers(1)
-        .bind(format!("[::0]:{}", SETTING.get_network().rita_contact_port))
-        .unwrap()
-        .shutdown_timeout(0)
-        .start();
+    .bind(format!("[::0]:{}", SETTING.get_network().rita_contact_port))
+    .unwrap()
+    .shutdown_timeout(0)
+    .start();
 
     // dashboard
     server::new(|| {
@@ -209,13 +209,12 @@ fn main() {
             .route("/info", Method::GET, get_own_info)
             .route("/version", Method::GET, version)
     }).workers(1)
-        .bind(format!(
-            "[::0]:{}",
-            SETTING.get_network().rita_dashboard_port
-        ))
-        .unwrap()
-        .shutdown_timeout(0)
-        .start();
+    .bind(format!(
+        "[::0]:{}",
+        SETTING.get_network().rita_dashboard_port
+    )).unwrap()
+    .shutdown_timeout(0)
+    .start();
 
     let common = rita_common::rita_loop::RitaLoop::new();
     let _: Addr<_> = common.start();

--- a/rita/src/exit.rs
+++ b/rita/src/exit.rs
@@ -190,10 +190,10 @@ fn main() {
             r.method(Method::POST).with(make_payments)
         })
     }).workers(1)
-        .bind(format!("[::0]:{}", SETTING.get_network().rita_contact_port))
-        .unwrap()
-        .shutdown_timeout(0)
-        .start();
+    .bind(format!("[::0]:{}", SETTING.get_network().rita_contact_port))
+    .unwrap()
+    .shutdown_timeout(0)
+    .start();
 
     // Exit stuff
     server::new(|| {
@@ -201,19 +201,16 @@ fn main() {
             .resource("/setup", |r| r.method(Method::POST).with(setup_request))
             .resource("/status", |r| {
                 r.method(Method::POST).with_async(status_request)
-            })
-            .resource("/list", |r| r.method(Method::POST).with(list_clients))
+            }).resource("/list", |r| r.method(Method::POST).with(list_clients))
             .resource("/exit_info", |r| {
                 r.method(Method::GET).with(get_exit_info_http)
-            })
-            .resource("/rtt", |r| r.method(Method::GET).with(rtt))
+            }).resource("/rtt", |r| r.method(Method::GET).with(rtt))
     }).bind(format!(
         "[::0]:{}",
         SETTING.get_exit_network().exit_hello_port
-    ))
-        .unwrap()
-        .shutdown_timeout(0)
-        .start();
+    )).unwrap()
+    .shutdown_timeout(0)
+    .start();
 
     // Dashboard
     server::new(|| {
@@ -229,10 +226,9 @@ fn main() {
     }).bind(format!(
         "[::0]:{}",
         SETTING.get_network().rita_dashboard_port
-    ))
-        .unwrap()
-        .shutdown_timeout(0)
-        .start();
+    )).unwrap()
+    .shutdown_timeout(0)
+    .start();
 
     let common = rita_common::rita_loop::RitaLoop::new();
     let _: Addr<_> = common.start();

--- a/rita/src/rita_client/traffic_watcher/mod.rs
+++ b/rita/src/rita_client/traffic_watcher/mod.rs
@@ -110,8 +110,7 @@ pub fn watch<T: Read + Write>(
                         ));
                     }
                 }
-            ))
-            .send()?
+            )).send()?
             .json()?;
         let client_rx = SystemTime::now();
 

--- a/rita/src/rita_common/network_endpoints/mod.rs
+++ b/rita/src/rita_common/network_endpoints/mod.rs
@@ -44,8 +44,7 @@ pub fn make_payments(
     PaymentController::from_registry()
         .send(rita_common::payment_controller::PaymentReceived(
             pmt.0.clone(),
-        ))
-        .from_err()
+        )).from_err()
         .and_then(|_| Ok(HttpResponse::Ok().into()))
         .responder()
 }
@@ -89,8 +88,7 @@ pub fn hello_response(
                         wg_port: wg_iface?.listen_port,
                     }))
                 })
-        })
-        .responder()
+        }).responder()
 }
 
 pub fn version(_req: HttpRequest) -> String {

--- a/rita/src/rita_common/tunnel_manager/mod.rs
+++ b/rita/src/rita_common/tunnel_manager/mod.rs
@@ -289,8 +289,7 @@ impl TunnelManager {
                     }
                 }
                 out
-            })
-            .filter_map(|(ip_address, dev)| {
+            }).filter_map(|(ip_address, dev)| {
                 info!("neighbor at interface {:?}, ip {}", dev, ip_address,);
                 if let Some(dev) = dev.clone() {
                     // Demorgans equal to "if a neighbor is on the listen interfaces and has a valid
@@ -326,8 +325,7 @@ impl TunnelManager {
                     )
                         as Box<Future<Item = Option<(LocalIdentity, String, IpAddr)>, Error = ()>>,
                 )
-            })
-            .collect();
+            }).collect();
         Box::new(futures::future::join_all(neighs).then(|res| {
             let mut output = Vec::new();
             for i in res.unwrap() {
@@ -418,8 +416,7 @@ impl TunnelManager {
                 .send(Hello {
                     my_id: SETTING.get_identity(),
                     to: socket,
-                })
-                .from_err()
+                }).from_err()
                 .and_then(move |res| match res {
                     Ok(res) => Box::new(
                         TunnelManager::from_registry()

--- a/rita/src/rita_exit/db_client/mod.rs
+++ b/rita/src/rita_exit/db_client/mod.rs
@@ -274,8 +274,7 @@ fn send_mail(client: &models::Client) -> Result<(), Error> {
             .credentials(Credentials::new(
                 SETTING.get_mailer().unwrap().smtp_username,
                 SETTING.get_mailer().unwrap().smtp_password,
-            ))
-            .smtp_utf8(true)
+            )).smtp_utf8(true)
             .authentication_mechanism(Mechanism::Plain)
             .connection_reuse(ConnectionReuseParameters::ReuseUnlimited)
             .build();

--- a/stats_server/src/main.rs
+++ b/stats_server/src/main.rs
@@ -52,8 +52,7 @@ fn index(
             resp.body()
                 .from_err()
                 .and_then(|body| Ok(HttpResponse::Ok().body(body)))
-        })
-        .responder()
+        }).responder()
 }
 
 fn main() {
@@ -72,10 +71,10 @@ fn main() {
         App::with_state(ProxyState {
             insert_url: insert_url.clone(),
         }).middleware(middleware::Logger::default())
-            .resource("/stats/", |r| r.method(http::Method::POST).with(index))
+        .resource("/stats/", |r| r.method(http::Method::POST).with(index))
     }).bind(args.flag_bind_url)
-        .unwrap()
-        .start();
+    .unwrap()
+    .start();
 
     let _ = sys.run();
 }


### PR DESCRIPTION
We run `cargo +nightly fmt` on travis, and at least in #159 this build
fails with diff. This change should address this issue.

If we're using `cargo +nightly fmt` on travis it might be good to run it as well in a `pre-commit` hook to save some time, just in case someone would forget to rerun formatter before committing.