### PR TITLE
Increase test timeout to 30 minutes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ env:
   - TEST_COMMAND="cargo build --verbose --all"
   - TEST_COMMAND="./integration-tests/cross-build.sh"
   - TEST_COMMAND="cargo test --verbose --all" RUST_TEST_THREADS=1
-  - TEST_COMMAND="./integration-tests/rita.sh" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
-  - TEST_COMMAND="./integration-tests/rita.sh" REVISION_B=release COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
-  - TEST_COMMAND="./integration-tests/rita.sh" REVISION_B=master COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
+  - TEST_COMMAND="travis_wait 30 ./integration-tests/rita.sh" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
+  - TEST_COMMAND="travis_wait 30 ./integration-tests/rita.sh" REVISION_B=release COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
+  - TEST_COMMAND="travis_wait 30 ./integration-tests/rita.sh" REVISION_B=master COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
 rust:
   - stable
   - beta
@@ -32,10 +32,10 @@ matrix:
   - rust: beta
     env: TEST_COMMAND="./integration-tests/cross-build.sh"
   - rust: stable
-    env: TEST_COMMAND="./integration-tests/rita.sh" REVISION_B=release COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
+    env: TEST_COMMAND="travis_wait 30 ./integration-tests/rita.sh" REVISION_B=release COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
   - rust: beta
-    env: TEST_COMMAND="./integration-tests/rita.sh" REVISION_B=release COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
+    env: TEST_COMMAND="travis_wait 30 ./integration-tests/rita.sh" REVISION_B=release COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
   - rust: stable
-    env: TEST_COMMAND="./integration-tests/rita.sh" REVISION_B=master COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
+    env: TEST_COMMAND="travis_wait 30 ./integration-tests/rita.sh" REVISION_B=master COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
   - rust: beta
-    env: TEST_COMMAND="./integration-tests/rita.sh" REVISION_B=master COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
+    env: TEST_COMMAND="travis_wait 30 ./integration-tests/rita.sh" REVISION_B=master COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ rust:
   - beta
   - nightly
 script:
-  - (eval "$TEST_COMMAND")
+  - eval "$TEST_COMMAND"
 matrix:
   exclude:
   - rust: stable


### PR DESCRIPTION
This increases timeout on tests from default 10 minutes, to 30 minutes.
This was observed at least once in #159, where integration tests build
failed because no output was received for 10 minutes.

More details: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received

Possible solution to #163