### PR TITLE
Fix warnings after moving to 1.28 stable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - which diesel || cargo install diesel_cli --no-default-features --features sqlite
   - sudo cp $(which diesel) /usr/bin
 env:
-  - TEST_COMMAND="cargo +nightly fmt --all -- --check"
+  - TEST_COMMAND="rustup component add rustfmt-preview && cargo +nightly fmt --all -- --check"
   - TEST_COMMAND="cargo build --verbose --all"
   - TEST_COMMAND="cargo test --verbose --all" RUST_TEST_THREADS=1
 rust:
@@ -26,9 +26,9 @@ matrix:
       env: TEST_COMMAND="cargo test --verbose --all" RUST_TEST_THREADS=1
   exclude:
     - rust: beta
-      env: TEST_COMMAND="cargo +nightly fmt --all -- --check"
+      env: TEST_COMMAND="rustup component add rustfmt-preview && cargo +nightly fmt --all -- --check"
     - rust: stable
-      env: TEST_COMMAND="cargo +nightly fmt --all -- --check"
+      env: TEST_COMMAND="rustup component add rustfmt-preview && cargo +nightly fmt --all -- --check"
   include:
     - name: "Cross compile on MIPS"
       script: ./integration-tests/cross-build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ matrix:
     - rust: nightly
   include:
     - name: "cargo fmt"
-      script: rustup component add rustfmt-preview --toolchain nightly && cargo fmt --all -- --check
+      # This runs on `stable` so thats why we call `rustup`.
+      script: rustup toolchain install nightly && rustup component add rustfmt-preview --toolchain nightly && cargo +nightly fmt --all -- --check
     - name: "Cross compile on MIPS"
       script: ./integration-tests/cross-build.sh
     - script: ./integration-tests/rita.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
   - which diesel || cargo install diesel_cli --no-default-features --features sqlite
   - sudo cp $(which diesel) /usr/bin
 env:
+  - TEST_COMMAND="cargo +nightly fmt --all -- --check"
   - TEST_COMMAND="cargo build --verbose --all"
   - TEST_COMMAND="cargo test --verbose --all" RUST_TEST_THREADS=1
 rust:
@@ -20,10 +21,12 @@ matrix:
   allow_failures:
     - rust: beta
     - rust: nightly
+  exclude:
+    - rust: beta
+      env: TEST_COMMAND="cargo +nightly fmt --all -- --check"
+    - rust: stable
+      env: TEST_COMMAND="cargo +nightly fmt --all -- --check"
   include:
-    - name: "cargo fmt"
-      # This runs on `stable` so thats why we call `rustup`.
-      script: rustup toolchain install nightly && rustup component add rustfmt-preview --toolchain nightly && cargo +nightly fmt --all -- --check
     - name: "Cross compile on MIPS"
       script: ./integration-tests/cross-build.sh
     - script: ./integration-tests/rita.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ matrix:
   allow_failures:
     - rust: beta
     - rust: nightly
+      env: TEST_COMMAND="cargo build --verbose --all"
+    - rust: nightly
+      env: TEST_COMMAND="cargo test --verbose --all" RUST_TEST_THREADS=1
   exclude:
     - rust: beta
       env: TEST_COMMAND="cargo +nightly fmt --all -- --check"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,8 @@ before_install:
   - which diesel || cargo install diesel_cli --no-default-features --features sqlite
   - sudo cp $(which diesel) /usr/bin
 env:
-  - TEST_COMMAND="rustup component add rustfmt-preview --toolchain nightly && cargo fmt --all -- --check"
   - TEST_COMMAND="cargo build --verbose --all"
-  - TEST_COMMAND="./integration-tests/cross-build.sh"
   - TEST_COMMAND="cargo test --verbose --all" RUST_TEST_THREADS=1
-  - TEST_COMMAND="./integration-tests/rita.sh" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
-  - TEST_COMMAND="./integration-tests/rita.sh" REVISION_B=release COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
-  - TEST_COMMAND="./integration-tests/rita.sh" REVISION_B=master COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
 rust:
   - stable
   - beta
@@ -22,20 +17,17 @@ rust:
 script:
   - (eval "$TEST_COMMAND")
 matrix:
-  exclude:
-  - rust: stable
-    env: TEST_COMMAND="rustup component add rustfmt-preview --toolchain nightly && cargo fmt --all -- --check"
-  - rust: beta
-    env: TEST_COMMAND="rustup component add rustfmt-preview --toolchain nightly && cargo fmt --all -- --check"
-  - rust: stable
-    env: TEST_COMMAND="./integration-tests/cross-build.sh"
-  - rust: beta
-    env: TEST_COMMAND="./integration-tests/cross-build.sh"
-  - rust: stable
-    env: TEST_COMMAND="./integration-tests/rita.sh" REVISION_B=release COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
-  - rust: beta
-    env: TEST_COMMAND="./integration-tests/rita.sh" REVISION_B=release COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
-  - rust: stable
-    env: TEST_COMMAND="./integration-tests/rita.sh" REVISION_B=master COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
-  - rust: beta
-    env: TEST_COMMAND="./integration-tests/rita.sh" REVISION_B=master COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
+  allow_failures:
+    - rust: beta
+    - rust: nightly
+  include:
+    - name: "cargo fmt"
+      script: rustup component add rustfmt-preview --toolchain nightly && cargo fmt --all -- --check
+    - name: "Cross compile on MIPS"
+      script: ./integration-tests/cross-build.sh
+    - script: ./integration-tests/rita.sh
+      env: INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
+    - script: ./integration-tests/rita.sh
+      env: REVISION_B=release COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
+    - script: ./integration-tests/rita.sh
+      env: REVISION_B=master COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - which diesel || cargo install diesel_cli --no-default-features --features sqlite
   - sudo cp $(which diesel) /usr/bin
 env:
-  - TEST_COMMAND="rustup component add rustfmt-preview && cargo +nightly fmt --all -- --check"
+  - TEST_COMMAND="rustup component add rustfmt-preview --toolchain nightly && cargo +nightly fmt --all -- --check"
   - TEST_COMMAND="cargo build --verbose --all"
   - TEST_COMMAND="cargo test --verbose --all" RUST_TEST_THREADS=1
 rust:
@@ -26,9 +26,9 @@ matrix:
       env: TEST_COMMAND="cargo test --verbose --all" RUST_TEST_THREADS=1
   exclude:
     - rust: beta
-      env: TEST_COMMAND="rustup component add rustfmt-preview && cargo +nightly fmt --all -- --check"
+      env: TEST_COMMAND="rustup component add rustfmt-preview --toolchain nightly && cargo +nightly fmt --all -- --check"
     - rust: stable
-      env: TEST_COMMAND="rustup component add rustfmt-preview && cargo +nightly fmt --all -- --check"
+      env: TEST_COMMAND="rustup component add rustfmt-preview --toolchain nightly && cargo +nightly fmt --all -- --check"
   include:
     - name: "Cross compile on MIPS"
       script: ./integration-tests/cross-build.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "althea_rs"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
- "rita 0.1.3",
+ "rita 0.1.4",
 ]
 
 [[package]]
@@ -1924,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "rita"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "actix 0.7.0 (git+https://github.com/kingoflolz/actix.git?branch=althea-mesh)",
  "actix-web 0.7.0 (git+https://github.com/actix/actix-web.git?branch=fix-missing-content-length)",
@@ -1955,7 +1955,7 @@ dependencies = [
  "mockito 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockstream 0.0.3 (git+https://github.com/lazy-bitfield/rust-mockstream.git)",
  "num256 0.1.0",
- "rand 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ You are now ready to build code from this Rust repository by running
 
 	cargo build --all
 
+## Development
+
+Please install required git hooks before contributing. Those hooks are responsible for making the codebase consistent.
+
+```sh
+rustup component add rustfmt-preview --toolchain nightly
+cd .git/hooks && ln -s ../../scripts/.git-hooks/pre-commit
+```
+
 ## Components
 
 ### Rita

--- a/rita/src/client.rs
+++ b/rita/src/client.rs
@@ -23,7 +23,6 @@ extern crate lazy_static;
 extern crate log;
 #[macro_use]
 extern crate serde_derive;
-#[macro_use]
 extern crate serde_json;
 
 extern crate actix;

--- a/rita/src/rita_client/dashboard/mod.rs
+++ b/rita/src/rita_client/dashboard/mod.rs
@@ -344,7 +344,7 @@ impl Handler<ResetExit> for Dashboard {
     fn handle(&mut self, msg: ResetExit, _ctx: &mut Self::Context) -> Self::Result {
         let mut exits = SETTING.get_exits_mut();
 
-        if let Some(mut exit) = exits.get_mut(&msg.0) {
+        if let Some(exit) = exits.get_mut(&msg.0) {
             info!("Changing exit {:?} state to New", msg.0);
             exit.info = ExitState::New;
         } else {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+edition = "Edition2018"

--- a/scripts/.git-hooks/pre-commit
+++ b/scripts/.git-hooks/pre-commit
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+inconsistent_files=()
+result=0
+
+while read file; do
+    if [ ${file: -3} == ".rs" ]; then
+        rustfmt +nightly --skip-children --check $file 1>/dev/null;
+        if [ $? != 0 ]; then
+        	inconsistent_files+=($file);
+            result=1
+        fi
+    fi
+done < <(git diff --name-only --cached)
+
+if [ $result != 0 ]; then
+    printf "Detected inconsistent formatting in: \n"
+    for file in $inconsistent_files; do
+        printf "    rustfmt +nightly $file\n";
+    done
+    printf "Or run 'rustfmt +nightly --all' to fix formatting across the codebase.\n";
+    exit 1
+fi


### PR DESCRIPTION
Enough said. Compiles without warnings on 1.28 stable. Part of effort on #164 