### PR TITLE
OpenWRT upload script should kill running Rita

### DIFF
--- a/scripts/openwrt_upload.sh
+++ b/scripts/openwrt_upload.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -eux
-export TARGET=mipsel
-export TRIPLE=mipsel-unknown-linux-musl
+export TARGET=mips
+export TRIPLE=mips-unknown-linux-musl
 export ROUTER_IP=192.168.10.1
 bash scripts/openwrt_build_$TARGET.sh
+set +e
+ssh root@$ROUTER_IP killall -9 rita
+set -e
 scp target/$TRIPLE/release/rita root@$ROUTER_IP:/tmp/rita
 ssh root@$ROUTER_IP RUST_BACKTRACE=FULL RUST_LOG=TRACE /tmp/rita --config=/etc/rita.toml --platform=linux &> out.log


### PR DESCRIPTION
This changes the upload script to use the most common device type (mips) and to automatically kill any running instances of Rita, allowing for easier use especially since the last instance in a debugging session usually remains stubbornly alive until you login to fix it. 