### PR TITLE
Exit registration endpoints

### DIFF
--- a/docs/api/router-dashboard.md
+++ b/docs/api/router-dashboard.md
@@ -105,8 +105,6 @@ This file documents the dashboard API found in Rita client.
 
 `curl 127.0.0.1:4877/exits`
 
-
-
 ## /exits/{nickname}/reset
 
 - URL: `<rita ip>:<rita_dashboard_port>/exits/{nickname}/reset'
@@ -116,11 +114,17 @@ This file documents the dashboard API found in Rita client.
 - Data Params: `None`
 - Success Response:
   - Code: 200 OK
-  - Contents: `null`
-- Error Response: `500 Server Error`
+  - Contents: `{}`
+- Error Response: `400 Bad Request`
+- Error Contents:
+```json
+{
+    "error": "<description>",
+}
+```
 - Sample Call:
 
-`curl 127.0.0.1:4877/exits/borked/reset`
+`curl -XPOST 127.0.0.1:4877/exits/borked/reset`
 
 ## /exits/{nickname}/select
 
@@ -131,11 +135,64 @@ This file documents the dashboard API found in Rita client.
 - Data Params: `None`
 - Success Response:
   - Code: 200 OK
-  - Contents: `null`
-- Error Response: `500 Server Error`
+  - Contents: `{}`
+- Error Response: `400 Bad Request`
+- Error Contents:
+```json
+{
+    "error": "<description>",
+}
+```
 - Sample Call:
 
-`curl 127.0.0.1:4877/exits/borked/reset`
+`curl -XPOST 127.0.0.1:4877/exits/borked/reset`
+
+## /exits/{nickname}/register
+
+- URL: `<rita ip>:<rita_dashboard_port>/exits/{nickname}/register'
+- Comment: Asks exit `{nickname}` to be registered
+- Method: `POST`
+- URL Params: `nickname`, string
+- Data Params: `None`
+- Success Response:
+  - Code: 200 OK
+  - Contents: `{}`
+- Error Response: `400 Bad Request`
+- Error Contents:
+```json
+{
+    "error": "<description>",
+    "rust_error": "<stringified_rust_error>"
+}
+```
+- Sample Call:
+
+`curl -XPOST 127.0.0.1:4877/exits/borked/register`
+
+## /exits/{nickname}/verify/{code}
+
+- URL: `<rita ip>:<rita_dashboard_port>/exits/{nickname}/verify/{code}'
+- Comment: After registering and receiving a verification code, asks exit
+  `{nickname}` for verification using `{code}`
+- Method: `POST`
+- URL Params:
+    - `nickname`, string
+    - `code`, string
+- Data Params: `None`
+- Success Response:
+  - Code: 200 OK
+  - Contents: `{}`
+- Error Response: `400 Bad Request`
+- Error Contents:
+```json
+{
+    "error": "<description>",
+    "rust_error": "<stringified_rust_error>"
+}
+```
+- Sample Call:
+
+`curl -XPOST 127.0.0.1:4877/exits/borked/register`
 
 ## /settings
 

--- a/integration-tests/rita.py
+++ b/integration-tests/rita.py
@@ -312,24 +312,20 @@ def switch_binaries(node_id):
             "BOUNTY_HUNTER:\t{}").format(RITA, RITA_EXIT, BOUNTY_HUNTER))
 
 def register_to_exit(node):
-    id = node.id
-    os.system("ip netns exec netlab-{id} curl -XPOST 127.0.0.1:4877/settings -H 'Content-Type: application/json' -i -d '{data}'"
-              .format(id=id, data=json.dumps({"exit_client": EXIT_SELECT})))
+    os.system(("ip netns exec netlab-{} curl -XPOST " +
+        "127.0.0.1:4877/exits/exit_a/register").format(node.id))
 
 def email_verif(node):
-    id = node.id
-
     email_text = read_email(node)
 
     code = re.search(r"\[([0-9]+)\]", email_text).group(1)
 
-    print(code)
+    print("Email code for node {} is {}".format(node.id, code))
 
-    os.system("ip netns exec netlab-{id} curl -XPOST 127.0.0.1:4877/settings -H 'Content-Type: application/json' -i -d '{data}'"
-              .format(id=id, data=json.dumps({"exit_client": {"exits": {"exit_a": {"email_code": code}}}})))
-
-    os.system("ip netns exec netlab-{id} curl 127.0.0.1:4877/settings"
-              .format(id=id))
+    exec_or_exit(("ip netns exec netlab-{} curl -XPOST " +
+        "127.0.0.1:4877/exits/exit_a/verify/{}").format(node.id, code))
+    exec_or_exit(("ip netns exec netlab-{} curl " +
+        "127.0.0.1:4877/settings").format(node.id))
 
 def read_email(node):
     id = node.id

--- a/rita/src/client.rs
+++ b/rita/src/client.rs
@@ -211,7 +211,12 @@ fn main() {
             .route("/wifi_settings/ssid", Method::POST, set_wifi_ssid)
             .route("/wifi_settings/pass", Method::POST, set_wifi_pass)
             .route("/wifi_settings/mesh", Method::POST, set_wifi_mesh)
-            .route("/info", Method::GET, get_own_info)
+            .route("/exits/{name}/register", Method::POST, register_to_exit)
+            .route(
+                "/exits/{name}/verify/{code}",
+                Method::POST,
+                verify_on_exit_with_code,
+            ).route("/info", Method::GET, get_own_info)
             .route("/version", Method::GET, version)
     }).workers(1)
     .bind(format!(

--- a/rita/src/rita_client/dashboard/mod.rs
+++ b/rita/src/rita_client/dashboard/mod.rs
@@ -349,55 +349,6 @@ impl Handler<GetExitInfo> for Dashboard {
 }
 
 #[derive(Debug)]
-pub struct ResetExit(String);
-
-impl Message for ResetExit {
-    type Result = Result<(), Error>;
-}
-
-impl Handler<ResetExit> for Dashboard {
-    type Result = Result<(), Error>;
-    fn handle(&mut self, msg: ResetExit, _ctx: &mut Self::Context) -> Self::Result {
-        let mut exits = SETTING.get_exits_mut();
-
-        if let Some(exit) = exits.get_mut(&msg.0) {
-            info!("Changing exit {:?} state to New", msg.0);
-            exit.info = ExitState::New;
-        } else {
-            error!("Requested a reset on an unknown exit {:?}", msg.0);
-            bail!("Requested a reset on an unknown exit {:?}", msg.0);
-        }
-
-        Ok(())
-    }
-}
-
-#[derive(Debug)]
-pub struct SelectExit(String);
-
-impl Message for SelectExit {
-    type Result = Result<(), Error>;
-}
-
-impl Handler<SelectExit> for Dashboard {
-    type Result = Result<(), Error>;
-    fn handle(&mut self, msg: SelectExit, _ctx: &mut Self::Context) -> Self::Result {
-        debug!("Attempting to select exit {:?}", msg.0);
-
-        let mut exit_client = SETTING.get_exit_client_mut();
-
-        if exit_client.exits.contains_key(&msg.0) {
-            info!("Selecting exit {:?}", msg.0);
-            exit_client.current_exit = Some(msg.0);
-        } else {
-            error!("Requested selection of an unknown exit {:?}", msg.0);
-            bail!("Requested selection of an unknown exit {:?}", msg.0);
-        }
-        Ok(())
-    }
-}
-
-#[derive(Debug)]
 pub struct SetWiFiSSID(WifiSSID);
 
 impl Message for SetWiFiSSID {


### PR DESCRIPTION
This PR adds two `/exits/{name}/register` and `/exits/{name}/verify/{code}` endpoints for handling both stages of exit registration. It supersedes the `auto_register` settings option.

Stuff still wrong/missing:
* [x] A `wait()` on the exit_setup_request() future seems to be hogging a resource for all "/exits"-suite requests.
* [x] Docs
* [x] `auto_register` and `email_code` still exist despite not being used - **A different PR will be open for this (issue #181)
* [x] Give explicit error reasons for failures and indicate appropriately with the status code