### PR TITLE
Pin docker image to `stable`.

### DIFF
--- a/scripts/linux_build_static.sh
+++ b/scripts/linux_build_static.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # You may need to disable or modify selinux
 set -eux
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-BUILDER="docker run --rm -it -v $(pwd):/home/rust/src ekidd/rust-musl-builder"
-pushd $DIR
-cargo clean
-$BUILDER cargo build --all --release
+
+RUST_TOOLCHAIN="stable"
+
+RUST_MUSL_BUILDER="docker run --rm -it -v "$(pwd)":/home/rust/src ekidd/rust-musl-builder:$RUST_TOOLCHAIN"
+$RUST_MUSL_BUILDER cargo build --all --release


### PR DESCRIPTION
This should fix problem mentioned in #168. By default it was using
`latest` docker image which might use `nightly` stuff.

After applying this fix I had no problems running `rita_exit`
whatsoever.