### PR TITLE
Catch `ValueError` regardless of py version.

### DIFF
--- a/integration-tests/rita.py
+++ b/integration-tests/rita.py
@@ -686,16 +686,16 @@ class World:
                 + "netlab-{} curl -sfg6 [::1]:4877/neighbors".format(node.id)),
                 stdout=subprocess.PIPE)
             assert_test(not result.wait(), "curl-ing /neighbors")
+            stdout = result.stdout.read().decode('utf-8')
             try:
                 print("Received neighbors:")
                 if VERBOSE:
-                    neighbors = json.loads(result.stdout.read().decode('utf-8'))
+                    neighbors = json.loads(stdout)
                     pprint(neighbors)
                 else:
-                    print(result.stdout.read().decode('utf-8'))
+                    print(stdout)
             except ValueError as e:
-                if VERBOSE:
-                    print('Unable to decode JSON {!r}: {!r}'.format(result, e))
+                print('Unable to decode JSON {!r}: {}'.format(stdout, e))
                 assert_test(False, "Decoding the neighbors JSON")
 
             # /exits
@@ -706,16 +706,16 @@ class World:
                 + "netlab-{} curl -sfg6 [::1]:4877/exits".format(node.id)),
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             assert_test(not result.wait(), "curl-ing /exits")
+            stdout = result.stdout.read().decode('utf-8')
             try:
                 print("Received exits:")
                 if VERBOSE:
-                    exits = json.loads(result.stdout.read().decode('utf-8'))
+                    exits = json.loads(stdout)
                     pprint(exits)
                 else:
-                    print(result.stdout.read().decode('utf-8'))
+                    print(stdout)
             except ValueError as e:
-                if VERBOSE:
-                    print('Unable to decode JSON {!r}: {!r}'.format(result, e))
+                print('Unable to decode JSON {!r}: {}'.format(stdout, e))
                 assert_test(False, "Decoding the exits JSON")
 
             # /info
@@ -726,16 +726,16 @@ class World:
                 + "netlab-{} curl -sfg6 [::1]:4877/info".format(node.id)),
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             assert_test(not result.wait(), "curl-ing /info")
+            stdout = result.stdout.read().decode('utf-8')
             try:
                 print("Received info:")
                 if VERBOSE:
-                    info = json.loads(result.stdout.read().decode('utf-8'))
+                    info = json.loads(stdout)
                     pprint(info)
                 else:
-                    print(result.stdout.read().decode('utf-8'))
+                    print(stdout)
             except ValueError as e:
-                if VERBOSE:
-                    print('Unable to decode JSON {!r}: {!r}'.format(result, e))
+                print('Unable to decode JSON {!r}: {}'.format(stdout, e))
                 assert_test(False, "Decoding the info JSON")
 
             # /settings
@@ -746,16 +746,16 @@ class World:
                 + "netlab-{} curl -sfg6 [::1]:4877/settings".format(node.id)),
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             assert_test(not result.wait(), "curl-ing /settings")
+            stdout = result.stdout.read().decode('utf-8')
             try:
                 print("Received settings:")
                 if VERBOSE:
-                    settings = json.loads(result.stdout.read().decode('utf-8'))
+                    settings = json.loads(stdout)
                     pprint(settings)
                 else:
-                    print(result.stdout.read().decode('utf-8'))
+                    print(stdout)
             except ValueError as e:
-                if VERBOSE:
-                    print('Unable to decode JSON {!r}: {!r}'.format(result, e))
+                print('Unable to decode JSON {!r}: {}'.format(stdout, e))
                 assert_test(False, "Decoding the settings JSON")
 
 

--- a/integration-tests/rita.py
+++ b/integration-tests/rita.py
@@ -693,7 +693,9 @@ class World:
                     pprint(neighbors)
                 else:
                     print(result.stdout.read().decode('utf-8'))
-            except json.JSONDecodeError as e:
+            except ValueError as e:
+                if VERBOSE:
+                    print('Unable to decode JSON {!r}: {!r}'.format(result, e))
                 assert_test(False, "Decoding the neighbors JSON")
 
             # /exits
@@ -711,7 +713,9 @@ class World:
                     pprint(exits)
                 else:
                     print(result.stdout.read().decode('utf-8'))
-            except json.JSONDecodeError as e:
+            except ValueError as e:
+                if VERBOSE:
+                    print('Unable to decode JSON {!r}: {!r}'.format(result, e))
                 assert_test(False, "Decoding the exits JSON")
 
             # /info
@@ -729,7 +733,9 @@ class World:
                     pprint(info)
                 else:
                     print(result.stdout.read().decode('utf-8'))
-            except json.JSONDecodeError as e:
+            except ValueError as e:
+                if VERBOSE:
+                    print('Unable to decode JSON {!r}: {!r}'.format(result, e))
                 assert_test(False, "Decoding the info JSON")
 
             # /settings
@@ -747,7 +753,9 @@ class World:
                     pprint(settings)
                 else:
                     print(result.stdout.read().decode('utf-8'))
-            except json.JSONDecodeError as e:
+            except ValueError as e:
+                if VERBOSE:
+                    print('Unable to decode JSON {!r}: {!r}'.format(result, e))
                 assert_test(False, "Decoding the settings JSON")
 
 


### PR DESCRIPTION
A small adhoc change. 

It turns out on travis sometimes we run rita.py on py2, where JSONDecodeError doesn't exist.

Example failed job: https://travis-ci.org/althea-mesh/althea_rs/jobs/413146414