### PR TITLE
Add /wipe endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "althea_rs"
 version = "0.1.4"
 authors = ["Stan Drozd <drozdziak1@gmail.com>"]
 
+[features]
+development = ["rita/development"]
+
 [dependencies]
 rita = { path = "./rita" }
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ You are now ready to build code from this Rust repository by running
 
 	cargo build --all
 
+If you want to build a development build that contains unsafe options that are not suitable for production usage:
+
+    cargo build --all --features development
+
 ## Development
 
 Please install required git hooks before contributing. Those hooks are responsible for making the codebase consistent.

--- a/clu/src/lib.rs
+++ b/clu/src/lib.rs
@@ -33,7 +33,7 @@ pub enum CluError {
     RuntimeError(String),
 }
 
-fn linux_generate_wg_keys(config: &mut NetworkSettings) -> Result<(), Error> {
+pub fn linux_generate_wg_keys(config: &mut NetworkSettings) -> Result<(), Error> {
     let keys = KI.create_wg_keypair()?;
     let wg_public_key = &keys[0];
     let wg_private_key = &keys[1];
@@ -45,7 +45,7 @@ fn linux_generate_wg_keys(config: &mut NetworkSettings) -> Result<(), Error> {
     Ok(())
 }
 
-fn linux_generate_mesh_ip(config: &mut NetworkSettings) -> Result<(), Error> {
+pub fn linux_generate_mesh_ip(config: &mut NetworkSettings) -> Result<(), Error> {
     let seed: String = thread_rng().gen_ascii_chars().take(50).collect();
     let mesh_ip = ipgen::ip(&seed, "fd00::/8").unwrap();
 

--- a/docs/api/router-dashboard.md
+++ b/docs/api/router-dashboard.md
@@ -494,3 +494,20 @@ This file documents the dashboard API found in Rita client.
 ---
 
 
+## /wipe
+
+**This endpoint works only on debug builds and is meant only for development purposes**
+
+- URL: `<rita ip>:<rita_dashboard_port>/wipe`
+- Method: `POST`
+- URL Params: `None`
+- Data Params: `None`
+- Success Response:
+  - Code: 204 NO CONTENT
+  - Contents: `None`
+- Error Response: `500 Server Error`
+- Sample Call:
+
+`curl -XPOST 127.0.0.1:<rita_dashboard_port>/wipe`
+
+---

--- a/docs/api/router-dashboard.md
+++ b/docs/api/router-dashboard.md
@@ -496,7 +496,7 @@ This file documents the dashboard API found in Rita client.
 
 ## /wipe
 
-**This endpoint works only on debug builds and is meant only for development purposes**
+**This endpoint works only on development builds and is meant only for development purposes**
 
 - URL: `<rita ip>:<rita_dashboard_port>/wipe`
 - Method: `POST`
@@ -509,5 +509,25 @@ This file documents the dashboard API found in Rita client.
 - Sample Call:
 
 `curl -XPOST 127.0.0.1:<rita_dashboard_port>/wipe`
+
+---
+
+## /database
+
+**This endpoint worsk only on development builds and is meant only for development purposes**
+
+Calling HTTP `DELETE` request on this endpoint causes all tables to be wiped out of data.
+
+- URL: `<rita ip>:<rita_dashboard_port>/wipe`
+- Method: `DELETE`
+- URL Params: `None`
+- Data Params: `None`
+- Success Response:
+  - Code: 204 NO CONTENT
+  - Contents: `None`
+- Error Response: `500 Server Error`
+- Sample Call:
+
+`curl -XDELETE 127.0.0.1:<rita_dashboard_port>/database`
 
 ---

--- a/rita/Cargo.toml
+++ b/rita/Cargo.toml
@@ -15,6 +15,8 @@ path = "src/client.rs"
 [features]
 default = []
 system_alloc = []
+development = []
+
 
 [dependencies]
 althea_kernel_interface = { path = "../althea_kernel_interface" }

--- a/rita/src/client.rs
+++ b/rita/src/client.rs
@@ -222,6 +222,7 @@ fn main() {
                 verify_on_exit_with_code,
             ).route("/info", Method::GET, get_own_info)
             .route("/version", Method::GET, version)
+            .route("/wipe", Method::POST, wipe)
     }).workers(1)
     .bind(format!(
         "[::0]:{}",

--- a/rita/src/client.rs
+++ b/rita/src/client.rs
@@ -156,6 +156,12 @@ fn main() {
     openssl_probe::init_ssl_cert_env_vars();
     env_logger::init();
 
+    if cfg!(feature = "development") {
+        println!("Warning!");
+        println!("This build is meant only for development purposes.");
+        println!("Running this on production is unsupported and not safe!");
+    }
+
     let args: Args = Docopt::new((*USAGE).as_str())
         .and_then(|d| d.deserialize())
         .unwrap_or_else(|e| e.exit());

--- a/rita/src/exit.rs
+++ b/rita/src/exit.rs
@@ -229,6 +229,7 @@ fn main() {
             .route("/settings", Method::POST, set_settings)
             .route("/version", Method::GET, version)
             .route("/wipe", Method::POST, wipe)
+            .route("/database", Method::DELETE, nuke_db)
     }).bind(format!(
         "[::0]:{}",
         SETTING.get_network().rita_dashboard_port

--- a/rita/src/exit.rs
+++ b/rita/src/exit.rs
@@ -228,6 +228,7 @@ fn main() {
             .route("/settings", Method::GET, get_settings)
             .route("/settings", Method::POST, set_settings)
             .route("/version", Method::GET, version)
+            .route("/wipe", Method::POST, wipe)
     }).bind(format!(
         "[::0]:{}",
         SETTING.get_network().rita_dashboard_port

--- a/rita/src/exit.rs
+++ b/rita/src/exit.rs
@@ -156,6 +156,12 @@ fn main() {
     openssl_probe::init_ssl_cert_env_vars();
     env_logger::init();
 
+    if cfg!(feature = "development") {
+        println!("Warning!");
+        println!("This build is meant only for development purposes.");
+        println!("Running this on production as an exit node is unsupported and not safe!");
+    }
+
     let args: Args = Docopt::new((*USAGE).as_str())
         .and_then(|d| d.deserialize())
         .unwrap_or_else(|e| e.exit());

--- a/rita/src/rita_common/dashboard/network_endpoints.rs
+++ b/rita/src/rita_common/dashboard/network_endpoints.rs
@@ -54,9 +54,12 @@ pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
 pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
     // Clean up existing WG interfaces
     match cleanup() {
-        Ok(_) => trace!("wipe: Cleanup success!"),
+        Ok(_) => trace!("wipe: WireGuard interfaces cleanup success!"),
         Err(e) => {
-            warn!("wipe: Unable to complete cleanup: {:?}", e);
+            warn!(
+                "wipe: Unable to complete WireGuard interfaces cleanup: {:?}",
+                e
+            );
             return Err(e);
         }
     }

--- a/rita/src/rita_common/dashboard/network_endpoints.rs
+++ b/rita/src/rita_common/dashboard/network_endpoints.rs
@@ -54,35 +54,35 @@ pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
 pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
     // Clean up existing WG interfaces
     match cleanup() {
-        Ok(_) => trace!("Cleanup success!"),
+        Ok(_) => trace!("wipe: Cleanup success!"),
         Err(e) => {
-            warn!("Unable to complete cleanup: {:?}", e);
+            warn!("wipe: Unable to complete cleanup: {:?}", e);
             return Err(e);
         }
     }
 
     // Restore default route
     match KI.restore_default_route(&mut SETTING.get_network_mut().default_route) {
-        Ok(_) => trace!("Restore default route success!"),
+        Ok(_) => trace!("wipe: Restore default route success!"),
         Err(e) => {
-            warn!("Unable to restore default route: {:?}", e);
+            warn!("wipe: Unable to restore default route: {:?}", e);
             return Err(e);
         }
     }
 
     // Create new WireGuard keys
     match linux_generate_wg_keys(&mut SETTING.get_network_mut()) {
-        Ok(_) => trace!("Generated new WireGuard keys"),
+        Ok(_) => trace!("wipe: Generated new WireGuard keys"),
         Err(e) => {
-            warn!("Unable to generate new WireGuard keys: {:?}", e);
+            warn!("wipe: Unable to generate new WireGuard keys: {:?}", e);
             return Err(e);
         }
     }
     // Generate new mesh IP
     match linux_generate_mesh_ip(&mut SETTING.get_network_mut()) {
-        Ok(_) => trace!("Generated new mesh IP"),
+        Ok(_) => trace!("wipe: Generated new mesh IP"),
         Err(e) => {
-            warn!("Unable to generate new mesh IP: {:?}", e);
+            warn!("wipe: Unable to generate new mesh IP: {:?}", e);
             return Err(e);
         }
     }
@@ -92,9 +92,9 @@ pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
         &Path::new(&SETTING.get_network().wg_private_key_path),
         &SETTING.get_network().wg_private_key,
     ) {
-        Ok(_) => trace!("Generated new WireGuard keys"),
+        Ok(_) => trace!("wipe: Generated new WireGuard keys"),
         Err(e) => {
-            warn!("Unable to generate new WireGuard keys: {:?}", e);
+            warn!("wipe: Unable to generate new WireGuard keys: {:?}", e);
             return Err(e);
         }
     }

--- a/rita/src/rita_common/dashboard/network_endpoints.rs
+++ b/rita/src/rita_common/dashboard/network_endpoints.rs
@@ -44,13 +44,13 @@ pub fn set_settings(
     JsonStatusResponse::new(Ok("New settings applied".to_string()))
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(feature = "development"))]
 pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
     // This is returned on production builds.
     Ok(HttpResponse::NotFound().finish())
 }
 
-#[cfg(debug_assertions)]
+#[cfg(feature = "development")]
 pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
     // Clean up existing WG interfaces
     match cleanup() {

--- a/rita/src/rita_common/dashboard/network_endpoints.rs
+++ b/rita/src/rita_common/dashboard/network_endpoints.rs
@@ -1,5 +1,9 @@
 use actix::registry::SystemService;
-use actix_web::*;
+use clu::cleanup;
+use clu::linux_generate_mesh_ip;
+use clu::linux_generate_wg_keys;
+use std::path::Path;
+use KI;
 
 use futures::Future;
 
@@ -13,7 +17,8 @@ use settings::RitaCommonSettings;
 use SETTING;
 
 use super::{Dashboard, GetOwnInfo, OwnInfo};
-use actix_web::{error, fs, http, HttpResponse};
+use actix_web::*;
+
 use rita_common::network_endpoints::JsonStatusResponse;
 
 pub fn get_own_info(_req: HttpRequest) -> Box<Future<Item = Json<OwnInfo>, Error = Error>> {
@@ -39,11 +44,57 @@ pub fn set_settings(
     JsonStatusResponse::new(Ok("New settings applied".to_string()))
 }
 
-pub fn wipe(_req: HttpRequest) -> impl Responder {
+pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
     if cfg!(not(debug_assertions)) {
-        return HttpResponse::new(http::StatusCode::NOT_FOUND);
+        return Ok(HttpResponse::NotFound().finish());
     }
 
-    // TODO: Implement wiping logic
-    HttpResponse::new(http::StatusCode::NO_CONTENT)
+    // Clean up existing WG interfaces
+    match cleanup() {
+        Ok(_) => trace!("Cleanup success!"),
+        Err(e) => {
+            warn!("Unable to complete cleanup: {:?}", e);
+            return Err(e);
+        }
+    }
+
+    // Restore default route
+    match KI.restore_default_route(&mut SETTING.get_network_mut().default_route) {
+        Ok(_) => trace!("Restore default route success!"),
+        Err(e) => {
+            warn!("Unable to restore default route: {:?}", e);
+            return Err(e);
+        }
+    }
+
+    // Create new WireGuard keys
+    match linux_generate_wg_keys(&mut SETTING.get_network_mut()) {
+        Ok(_) => trace!("Generated new WireGuard keys"),
+        Err(e) => {
+            warn!("Unable to generate new WireGuard keys: {:?}", e);
+            return Err(e);
+        }
+    }
+    // Generate new mesh IP
+    match linux_generate_mesh_ip(&mut SETTING.get_network_mut()) {
+        Ok(_) => trace!("Generated new mesh IP"),
+        Err(e) => {
+            warn!("Unable to generate new mesh IP: {:?}", e);
+            return Err(e);
+        }
+    }
+
+    // Creates file on disk containing key
+    match KI.create_wg_key(
+        &Path::new(&SETTING.get_network().wg_private_key_path),
+        &SETTING.get_network().wg_private_key,
+    ) {
+        Ok(_) => trace!("Generated new WireGuard keys"),
+        Err(e) => {
+            warn!("Unable to generate new WireGuard keys: {:?}", e);
+            return Err(e);
+        }
+    }
+
+    Ok(HttpResponse::NoContent().finish())
 }

--- a/rita/src/rita_common/dashboard/network_endpoints.rs
+++ b/rita/src/rita_common/dashboard/network_endpoints.rs
@@ -47,7 +47,7 @@ pub fn set_settings(
 #[cfg(not(debug_assertions))]
 pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
     // This is returned on production builds.
-    Ok(HttpResponse::NotFound().finish());
+    Ok(HttpResponse::NotFound().finish())
 }
 
 #[cfg(debug_assertions)]

--- a/rita/src/rita_common/dashboard/network_endpoints.rs
+++ b/rita/src/rita_common/dashboard/network_endpoints.rs
@@ -44,11 +44,14 @@ pub fn set_settings(
     JsonStatusResponse::new(Ok("New settings applied".to_string()))
 }
 
+#[cfg(not(debug_assertions))]
 pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
-    if cfg!(not(debug_assertions)) {
-        return Ok(HttpResponse::NotFound().finish());
-    }
+    // This is returned on production builds.
+    Ok(HttpResponse::NotFound().finish());
+}
 
+#[cfg(debug_assertions)]
+pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
     // Clean up existing WG interfaces
     match cleanup() {
         Ok(_) => trace!("Cleanup success!"),

--- a/rita/src/rita_common/dashboard/network_endpoints.rs
+++ b/rita/src/rita_common/dashboard/network_endpoints.rs
@@ -13,7 +13,7 @@ use settings::RitaCommonSettings;
 use SETTING;
 
 use super::{Dashboard, GetOwnInfo, OwnInfo};
-
+use actix_web::{error, fs, http, HttpResponse};
 use rita_common::network_endpoints::JsonStatusResponse;
 
 pub fn get_own_info(_req: HttpRequest) -> Box<Future<Item = Json<OwnInfo>, Error = Error>> {
@@ -37,4 +37,13 @@ pub fn set_settings(
     SETTING.merge(new_settings.into_inner())?;
 
     JsonStatusResponse::new(Ok("New settings applied".to_string()))
+}
+
+pub fn wipe(_req: HttpRequest) -> impl Responder {
+    if cfg!(not(debug_assertions)) {
+        return HttpResponse::new(http::StatusCode::NOT_FOUND);
+    }
+
+    // TODO: Implement wiping logic
+    HttpResponse::new(http::StatusCode::NO_CONTENT)
 }

--- a/rita/src/rita_common/dashboard/network_endpoints.rs
+++ b/rita/src/rita_common/dashboard/network_endpoints.rs
@@ -95,9 +95,9 @@ pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
         &Path::new(&SETTING.get_network().wg_private_key_path),
         &SETTING.get_network().wg_private_key,
     ) {
-        Ok(_) => trace!("wipe: Generated new WireGuard keys"),
+        Ok(_) => trace!("wipe: Saved new WireGuard keys to disk"),
         Err(e) => {
-            warn!("wipe: Unable to generate new WireGuard keys: {:?}", e);
+            warn!("wipe: Unable to save new WireGuard keys: {:?}", e);
             return Err(e);
         }
     }

--- a/rita/src/rita_exit/db_client/mod.rs
+++ b/rita/src/rita_exit/db_client/mod.rs
@@ -460,3 +460,20 @@ impl Handler<ClientStatus> for DbClient {
         })
     }
 }
+
+pub struct TruncateTables;
+impl Message for TruncateTables {
+    type Result = Result<(), Error>;
+}
+
+impl Handler<TruncateTables> for DbClient {
+    type Result = Result<(), Error>;
+
+    fn handle(&mut self, _: TruncateTables, _: &mut Self::Context) -> Self::Result {
+        use self::schema::clients::dsl::*;
+        info!("Deleting all clients in {:?}", &SETTING.get_db_file());
+        let connection = SqliteConnection::establish(&SETTING.get_db_file()).unwrap();
+        try!(delete(clients).execute(&connection));
+        Ok(())
+    }
+}

--- a/rita/src/rita_exit/network_endpoints/mod.rs
+++ b/rita/src/rita_exit/network_endpoints/mod.rs
@@ -97,6 +97,6 @@ pub fn nuke_db(_req: HttpRequest) -> Box<Future<Item = HttpResponse, Error = Err
     DbClient::from_registry()
         .send(TruncateTables {})
         .from_err()
-        .and_then(move |reply| Ok(HttpResponse::NoContent().finish()))
+        .and_then(move |_| Ok(HttpResponse::NoContent().finish()))
         .responder()
 }

--- a/rita/src/rita_exit/network_endpoints/mod.rs
+++ b/rita/src/rita_exit/network_endpoints/mod.rs
@@ -85,14 +85,15 @@ pub fn rtt(_req: HttpRequest) -> Result<Json<RTTimestamps>> {
     }))
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(feature = "development"))]
 pub fn nuke_db(_req: HttpRequest) -> Result<HttpResponse, Error> {
     // This is returned on production builds.
     Ok(HttpResponse::NotFound().finish())
 }
 
-#[cfg(debug_assertions)]
+#[cfg(feature = "development")]
 pub fn nuke_db(_req: HttpRequest) -> Box<Future<Item = HttpResponse, Error = Error>> {
+    trace!("nuke_db: Truncating all data from the database");
     DbClient::from_registry()
         .send(TruncateTables {})
         .from_err()

--- a/scripts/build_common.sh
+++ b/scripts/build_common.sh
@@ -1,3 +1,25 @@
+# This bash script contains shared logic that is used to parse
+# command line arguments. It is meant to be sourced from within the
+# build scripts.
+# This script parses command line arguments and exposes variables such
+# as $PROFILE, and $FEATURES.
+#
+# Variables:
+#
+# $PROFILE: Can contain "--release" or "". By default it is set to
+#           "--release".
+# $FEATURES: Contains a value of a feature passed by "--feature foo",
+#            as "--feature foo". In case of no --feature switch is
+#            found in $@ then empty string is used.
+#
+# Example:
+#
+# $ source ./build_common.sh --release --feature foo
+# $ echo $FEATURES
+# --features foo
+# $ echo $PROFILE
+# --release
+
 # Builds release profile unless specified other
 PROFILE="--release"
 # Features switch that will be passed to cargo in a docker container

--- a/scripts/build_common.sh
+++ b/scripts/build_common.sh
@@ -1,0 +1,35 @@
+# Builds release profile unless specified other
+PROFILE="--release"
+# Features switch that will be passed to cargo in a docker container
+FEATURES=""
+
+# Parse arguemnmts
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+    case $key in
+        --debug)
+        # Without this argument cargo builds dev binary by default
+        PROFILE=""
+        shift
+        ;;
+        --release)
+        PROFILE="--release"
+        shift
+        ;;
+        --features)
+        FEATURES="$2"
+        shift
+        shift
+        ;;
+        *)
+        shift
+        ;;
+    esac
+done
+
+# Prepare `--features $FOO` only if --features is passed to this script.
+if [ "$FEATURES" != '' ]; then
+    # Add --features with the input provided
+    FEATURES="--features $FEATURES"
+fi

--- a/scripts/linux_build_static.sh
+++ b/scripts/linux_build_static.sh
@@ -1,8 +1,28 @@
 #!/bin/bash
-# You may need to disable or modify selinux
+# Usage: ./linux_build_static [--debug] [--release]
+#
+# This script builds a static Linux binaries.
+#
+# Options:
+#   --debug (optional) Use debug profile
+#   --release (optional) Use release profile (default)
+#   --feature (optional) List of features to build
+#
+# Note: You may need to disable or modify selinux, or add $USER to docker group
+# to be able to use `docker`.
 set -eux
 
-RUST_TOOLCHAIN="stable"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-RUST_MUSL_BUILDER="docker run --rm -it -v "$(pwd)":/home/rust/src ekidd/rust-musl-builder:$RUST_TOOLCHAIN"
-$RUST_MUSL_BUILDER cargo build --all --release
+# Parse command line arguments
+source $DIR/build_common.sh
+
+RUST_TOOLCHAIN="stable"
+CARGO_ROOT="$HOME/.cargo"
+CARGO_GIT="$CARGO_ROOT/.git"
+CARGO_REGISTRY="$CARGO_ROOT/registry"
+
+RUST_MUSL_BUILDER="docker run --rm -it -v "$(pwd)":/home/rust/src -v $CARGO_GIT:/home/rust/.cargo/git -v $CARGO_REGISTRY:/home/rust/.cargo/registry ekidd/rust-musl-builder:$RUST_TOOLCHAIN"
+$RUST_MUSL_BUILDER sudo chown -R rust:rust /home/rust/.cargo/git /home/rust/.cargo/registry
+
+$RUST_MUSL_BUILDER cargo build --all ${PROFILE} ${FEATURES}

--- a/scripts/openwrt_build_ipq40xx.sh
+++ b/scripts/openwrt_build_ipq40xx.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Parse command line arguments
+source $DIR/build_common.sh
+
 if [[ ! -d $DIR/staging_dir ]]; then
     pushd $DIR
     wget -N https://updates.altheamesh.com/staging.tar.xz -O staging.tar.xz > /dev/null; tar -xf staging.tar.xz
 fi
+
+
 
 export TOOLCHAIN=toolchain-arm_cortex-a7+neon-vfpv4_gcc-7.3.0_musl_eabi
 export TARGET_CC=$DIR/staging_dir/$TOOLCHAIN/bin/arm-openwrt-linux-gcc
@@ -17,4 +23,4 @@ export OPENSSL_STATIC=1
 
 rustup target add armv7-unknown-linux-musleabihf
 
-cargo build --target armv7-unknown-linux-musleabihf --release -p rita --bin rita
+cargo build --target armv7-unknown-linux-musleabihf ${PROFILE} ${FEATURES} -p rita --bin rita

--- a/scripts/openwrt_build_mips.sh
+++ b/scripts/openwrt_build_mips.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Parse command line arguments
+source $DIR/build_common.sh
+
 if [[ ! -d $DIR/staging_dir ]]; then
     pushd $DIR
     wget -N https://updates.altheamesh.com/staging.tar.xz -O staging.tar.xz > /dev/null; tar -xf staging.tar.xz
@@ -17,4 +21,4 @@ export OPENSSL_STATIC=1
 
 rustup target add mips-unknown-linux-musl
 
-cargo build --target mips-unknown-linux-musl --release -p rita --bin rita
+cargo build --target mips-unknown-linux-musl ${PROFILE} ${FEATURES} -p rita --bin rita

--- a/scripts/openwrt_build_mipsel.sh
+++ b/scripts/openwrt_build_mipsel.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Parse command line arguments
+source $DIR/build_common.sh
+
 if [[ ! -d $DIR/staging_dir ]]; then
     pushd $DIR
     wget -N https://updates.altheamesh.com/staging.tar.xz -O staging.tar.xz > /dev/null; tar -xf staging.tar.xz
@@ -17,4 +21,4 @@ export OPENSSL_STATIC=1
 
 rustup target add mipsel-unknown-linux-musl
 
-cargo build --target mipsel-unknown-linux-musl --release -p rita --bin rita
+cargo build --target mipsel-unknown-linux-musl ${PROFILE} ${FEATURES} -p rita --bin rita

--- a/scripts/openwrt_build_mvebu.sh
+++ b/scripts/openwrt_build_mvebu.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Parse command line arguments
+source $DIR/build_common.sh
+
 if [[ ! -d $DIR/staging_dir ]]; then
     pushd $DIR
     wget -N https://updates.altheamesh.com/staging.tar.xz -O staging.tar.xz > /dev/null; tar -xf staging.tar.xz
@@ -17,4 +21,4 @@ export OPENSSL_STATIC=1
 
 rustup target add armv7-unknown-linux-musleabihf
 
-cargo build --target armv7-unknown-linux-musleabihf --release -p rita --bin rita
+cargo build --target armv7-unknown-linux-musleabihf ${PROFILE} ${FEATURES} -p rita --bin rita

--- a/scripts/openwrt_build_octeon.sh
+++ b/scripts/openwrt_build_octeon.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Parse command line arguments
+source $DIR/build_common.sh
+
 if [[ ! -d $DIR/staging_dir ]]; then
     pushd $DIR
     wget -N https://updates.altheamesh.com/staging.tar.xz -O staging.tar.xz > /dev/null; tar -xf staging.tar.xz
@@ -17,4 +21,4 @@ export OPENSSL_STATIC=1
 
 rustup target add mips64-unknown-linux-gnuabi64
 
-cargo build --target mips64-unknown-linux-gnuabi64 --release -p rita --bin rita
+cargo build --target mips64-unknown-linux-gnuabi64 ${PROFILE} ${FEATURES} -p rita --bin rita

--- a/scripts/openwrt_upload.sh
+++ b/scripts/openwrt_upload.sh
@@ -3,7 +3,7 @@ set -eux
 export TARGET=mips
 export TRIPLE=mips-unknown-linux-musl
 export ROUTER_IP=192.168.10.1
-bash scripts/openwrt_build_$TARGET.sh
+bash scripts/openwrt_build_$TARGET.sh $@
 set +e
 ssh root@$ROUTER_IP killall -9 rita
 set -e


### PR DESCRIPTION
This adds `/wipe` endpoint to dashboard server. It removes WG interface, and recreates keys both in settings & on disk. This should fix #173.

- [x] 404 based on `--release`, wipes data on `--debug`.
- [x] WireGuard keys in settings
- [x] Mesh IP address regenerated
- [x] WG Priv key on disk recreated
- [x] ~Eth address recreate~ before guac integration which would handle Eth addresses we can ship what we have for now. Opinions?