### PR TITLE
Use openssl-probe crate to fix cert errors.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,6 +1609,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,6 +1975,7 @@ dependencies = [
  "mockito 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockstream 0.0.3 (git+https://github.com/lazy-bitfield/rust-mockstream.git)",
  "num256 0.1.0",
+ "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3040,6 +3046,7 @@ dependencies = [
 "checksum num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "630de1ef5cc79d0cdd78b7e33b81f083cbfe90de0f4b2b2f07f905867c70e9fe"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
+"checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.33 (registry+https://github.com/rust-lang/crates.io-index)" = "d8abc04833dcedef24221a91852931df2f63e3369ae003134e70aff3645775cc"
 "checksum owning_ref 0.3.3 (git+https://github.com/kingoflolz/owning-ref-rs/?branch=fix-bug)" = "<none>"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"

--- a/rita/Cargo.toml
+++ b/rita/Cargo.toml
@@ -59,3 +59,4 @@ regex = "1.0.2"
 trust-dns-resolver = "0.9.0"
 handlebars = "1.0.0"
 byteorder = { version = "1.2.4", features = ["i128"] }
+openssl-probe = "0.1.2"

--- a/rita/src/client.rs
+++ b/rita/src/client.rs
@@ -79,6 +79,8 @@ use rita_client::dashboard::network_endpoints::*;
 use rita_common::dashboard::network_endpoints::*;
 use rita_common::network_endpoints::*;
 
+extern crate openssl_probe;
+
 #[derive(Debug, Deserialize)]
 struct Args {
     flag_config: String,
@@ -150,6 +152,9 @@ lazy_static! {
 }
 
 fn main() {
+    // On Linux static builds we need to probe ssl certs path to be able to
+    // do TLS stuff.
+    openssl_probe::init_ssl_cert_env_vars();
     env_logger::init();
 
     let args: Args = Docopt::new((*USAGE).as_str())

--- a/rita/src/client.rs
+++ b/rita/src/client.rs
@@ -38,6 +38,7 @@ extern crate ipnetwork;
 extern crate lettre;
 extern crate lettre_email;
 extern crate minihttpse;
+extern crate openssl_probe;
 extern crate rand;
 extern crate regex;
 extern crate reqwest;
@@ -78,8 +79,6 @@ mod rita_common;
 use rita_client::dashboard::network_endpoints::*;
 use rita_common::dashboard::network_endpoints::*;
 use rita_common::network_endpoints::*;
-
-extern crate openssl_probe;
 
 #[derive(Debug, Deserialize)]
 struct Args {

--- a/rita/src/exit.rs
+++ b/rita/src/exit.rs
@@ -81,6 +81,7 @@ use std::sync::{Arc, RwLock};
 #[cfg(test)]
 use std::sync::Mutex;
 
+extern crate openssl_probe;
 #[derive(Debug, Deserialize)]
 struct Args {
     flag_config: String,
@@ -150,6 +151,9 @@ lazy_static! {
 }
 
 fn main() {
+    // On Linux static builds we need to probe ssl certs path to be able to
+    // do TLS stuff.
+    openssl_probe::init_ssl_cert_env_vars();
     env_logger::init();
 
     let args: Args = Docopt::new((*USAGE).as_str())

--- a/rita/src/exit.rs
+++ b/rita/src/exit.rs
@@ -42,6 +42,7 @@ extern crate ipnetwork;
 extern crate lettre;
 extern crate lettre_email;
 extern crate minihttpse;
+extern crate openssl_probe;
 extern crate rand;
 extern crate regex;
 extern crate reqwest;
@@ -81,7 +82,6 @@ use std::sync::{Arc, RwLock};
 #[cfg(test)]
 use std::sync::Mutex;
 
-extern crate openssl_probe;
 #[derive(Debug, Deserialize)]
 struct Args {
     flag_config: String,


### PR DESCRIPTION
Reproduced the issue with `linux_build_static.sh` and using a simple `reqwest` HTTPS call.

This should fix #183.