### PR TITLE
Resolve tunnel state disagreement

### DIFF
--- a/althea_types/src/interop.rs
+++ b/althea_types/src/interop.rs
@@ -146,6 +146,7 @@ impl Message for Identity {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
 pub struct LocalIdentity {
     pub wg_port: u16,
+    pub have_tunnel: Option<bool>, // If we have an existing tunnel, None if we don't know
     pub global: Identity,
 }
 

--- a/rita/src/rita_common/http_client/mod.rs
+++ b/rita/src/rita_common/http_client/mod.rs
@@ -45,7 +45,7 @@ impl Message for Hello {
 impl Handler<Hello> for HTTPClient {
     type Result = ResponseFuture<(), Error>;
     fn handle(&mut self, msg: Hello, _: &mut Self::Context) -> Self::Result {
-        info!("HTTPClient Sending Hello {:?}", msg);
+        info!("Sending Hello {:?}", msg);
 
         let stream = TokioTcpStream::connect(&msg.to.contact_socket);
 
@@ -85,7 +85,6 @@ impl Handler<Hello> for HTTPClient {
 
             trace!("sending hello request {:?}", network_json);
 
-            //TODO in case of failure we must return the port to the list via a callback!
             let http_result = network_json.send().then(move |response| {
                 trace!("got response from Hello {:?}", response);
                 match response {

--- a/rita/src/rita_common/network_endpoints/mod.rs
+++ b/rita/src/rita_common/network_endpoints/mod.rs
@@ -80,9 +80,11 @@ pub fn hello_response(
     TunnelManager::from_registry()
         .send(IdentityCallback(their_id, peer, None))
         .and_then(|tunnel| {
+            let tunnel = tunnel.unwrap();
             Ok(Json(LocalIdentity {
                 global: SETTING.get_identity(),
-                wg_port: tunnel.unwrap().listen_port,
+                wg_port: tunnel.0.listen_port,
+                have_tunnel: Some(tunnel.1),
             }))
         }).from_err()
         .responder()


### PR DESCRIPTION
Before the Peer discovery refactor we would always mutate the existing
tunnel during a successful identity exchange. Now we maintain a tunnel
state and only make modifications when required.

This works fine until one side reboots and the other does not, now there
is disagreement over what the tunnel state is. We need to introduce a single
bit of extra state. We can't do this by not sending hellos when tunnels are
already open. Because in NAT punching cases this prevents tunnel opening totally.

Accepting that we need constant hello sending as a liveness measure we need a way
for one side to indicate to the other that a problem exits. So we send a bool have_tunnel
with our identity, indicating that we do or do not have a tunnel with the peer already.

To complicate matters we don't actually know when we send our hello if we already have
a tunnel, because we send hello's to IP's but open tunnels with identities. To resolve
this bootstrapping problem the bool is wrapped in an option.

So the total system has two bools wrapped in options, that's effectively 16 possible
states. The possible states are reduced to 6 due to these constraints.

Hello responses always include Some(bool) since the hello has an identity we can use for the
lookup.

When a None is recieved we interpret it as 'True' so that we don't delete a tunnel that
might be perfectly fine

Therefore there is only one state in which we take corrective action based on this bool, which is when we have a tunnel but the hello response said they do not. In that case we delete our current tunnel
and create a new one matching the local identity sent in the message that's currently being
processed.

With this system no matter what state any side is in one side is garunteed to either be in
the right state already or take action to correct the tunnel state.

Even in the case that the option is somehow eliminated in the future everything will work, because only the state (true, false) results in a tunnel reset. 