### PR TITLE
rita.sh: Change default revisions to ""

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,6 @@ matrix:
     - script: ./integration-tests/rita.sh
       env: INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
     - script: ./integration-tests/rita.sh
-      env: REVISION_B=release REMOTE_A=.. COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
+      env: REVISION_B=release REMOTE_A=.. REMOTE_B="https://github.com/althea-mesh/althea_rs.git" COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
     - script: ./integration-tests/rita.sh
-      env: REVISION_B=master REMOTE_A=.. COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1
+      env: REVISION_B=master REMOTE_A=.. REMOTE_B="https://github.com/althea-mesh/althea_rs.git" COMPAT_LAYOUT="inner_ring_old" INITIAL_POLL_INTERVAL=5 BACKOFF_FACTOR="1.5" VERBOSE=1

--- a/integration-tests/rita.sh
+++ b/integration-tests/rita.sh
@@ -4,12 +4,12 @@ BABELD_DIR="deps/babeld"
 NETLAB_PATH="deps/network-lab/network-lab.sh"
 
 REMOTE_A=${REMOTE_A:=https://github.com/althea-mesh/althea_rs.git}
-REVISION_A=${REVISION_A:=master}
+REVISION_A=${REVISION_A:=""}
 DIR_A=${DIR_A:=althea_rs_a} # Don't override without good reason, this one and $DIR_B are git ignored
 TARGET_DIR_A=${TARGET_DIR_A:=target_a} # Don't override without good reason, this one and $TARGET_DIR_B are git ignored
 
 REMOTE_B=${REMOTE_B:=$REMOTE_A}
-REVISION_B=${REVISION_B:=release}
+REVISION_B=${REVISION_B:=$RELEASE_A}
 DIR_B=${DIR_B:=althea_rs_b}
 TARGET_DIR_B=${TARGET_DIR_B:=target_b}
 
@@ -27,7 +27,10 @@ build_rev() {
   dir=$3
   target_dir=$4
 
-  git show
+  if [ -z "${VERBOSE-}" ] ; then
+    git --no-pager show
+  fi
+
   mkdir -p $target_dir
 
   if [ -z "${NO_PULL-}" ] ; then
@@ -60,7 +63,7 @@ fi
 
 # Only care about revisions if a compat layout was picked
 if [ ! -z "${COMPAT_LAYOUT-}" ] ; then
-  build_rev $REMOTE_A $REVISION_A $DIR_A $TARGET_DIR_A
+  build_rev $REMOTE_A "$REVISION_A" $DIR_A $TARGET_DIR_A
   export RITA_A="$target_dir/debug/rita"
   export RITA_EXIT_A="$target_dir/debug/rita_exit"
   export BOUNTY_HUNTER_A="$target_dir/debug/bounty_hunter"
@@ -69,7 +72,7 @@ if [ ! -z "${COMPAT_LAYOUT-}" ] ; then
   # Save on common dep artifacts between A and B
   cp -r $TARGET_DIR_A $TARGET_DIR_B
 
-  build_rev $REMOTE_B $REVISION_B $DIR_B $TARGET_DIR_B
+  build_rev $REMOTE_B "$REVISION_B" $DIR_B $TARGET_DIR_B
   export RITA_B="$target_dir/debug/rita"
   export RITA_EXIT_B="$target_dir/debug/rita_exit"
   export BOUNTY_HUNTER_B="$target_dir/debug/bounty_hunter"


### PR DESCRIPTION
This fixes a design flaw that the integration tests had up until now.
Namely, in CI we would test againsta master and not the PR's feature
branch.

The solution works because git's default behavior is to check out a repo
clone where the remote repo was checked out at.

rita.sh:
* Default REVISION_A to "" and REVISION_B to REVISION_A
* Make "git show" not use a pager and only be issued under VERBOSE

.travis.yml:
* Account for new revision defaults