### PR TITLE
Remove stats collection from Rita loop

### DIFF
--- a/rita/src/rita_common/rita_loop/mod.rs
+++ b/rita/src/rita_common/rita_loop/mod.rs
@@ -69,10 +69,6 @@ impl Handler<Tick> for RitaLoop {
     fn handle(&mut self, _: Tick, ctx: &mut Context<Self>) -> Self::Result {
         trace!("Common tick!");
 
-        // let mut babel = Babel::new(&format!("[::1]:{}", SETTING.get_network().babel_port).parse().unwrap());
-
-        self.stats_collector.do_send(Tick {});
-
         // Resolves the gateway client corner case
         // Background info here https://forum.altheamesh.com/t/the-gateway-client-corner-case/35
         if SETTING.get_network().is_gateway {


### PR DESCRIPTION
Stats collection is blocking and if enabled will cause the main program
loop to go into a latency death spiral where it takes longer and longer
for any of the futures to resolve.

Furthermore I will assert that we should never integrate stats into the main loop
and in fact we should consider making a separate loops as much as possible to
isolate futures triggering issues if at all possible. 