### PR TITLE
Added debts API

### DIFF
--- a/althea_kernel_interface/src/delete_tunnel.rs
+++ b/althea_kernel_interface/src/delete_tunnel.rs
@@ -7,7 +7,7 @@ impl KernelInterface {
         let output = self.run_command("ip", &["link", "del", &interface])?;
         if !output.stderr.is_empty() {
             return Err(KernelInterfaceError::RuntimeError(format!(
-                "recieved error deleting wireguard interface: {}",
+                "received error deleting wireguard interface: {}",
                 String::from_utf8(output.stderr)?
             )).into());
         }

--- a/althea_kernel_interface/src/manipulate_uci.rs
+++ b/althea_kernel_interface/src/manipulate_uci.rs
@@ -7,7 +7,7 @@ impl KernelInterface {
         let output = self.run_command(command, args)?;
         if !output.stderr.is_empty() {
             return Err(KernelInterfaceError::RuntimeError(format!(
-                "recieved error while setting UCI: {}",
+                "received error while setting UCI: {}",
                 String::from_utf8(output.stderr)?
             )).into());
         }
@@ -50,7 +50,7 @@ impl KernelInterface {
         let output = self.run_command("uci", &["show", &key])?;
         if !output.stderr.is_empty() {
             return Err(KernelInterfaceError::RuntimeError(format!(
-                "recieved error while getting UCI: {}",
+                "received error while getting UCI: {}",
                 String::from_utf8(output.stderr)?
             )).into());
         }
@@ -62,7 +62,7 @@ impl KernelInterface {
         let output = self.run_command("uci", &["commit"])?;
         if !output.status.success() {
             return Err(KernelInterfaceError::RuntimeError(format!(
-                "recieved error while commiting UCI: {}",
+                "received error while commiting UCI: {}",
                 String::from_utf8(output.stderr)?
             )).into());
         }
@@ -73,7 +73,7 @@ impl KernelInterface {
         let output = self.run_command(&format!("/etc/init.d/{}", program), &["reload"])?;
         if !output.status.success() {
             return Err(KernelInterfaceError::RuntimeError(format!(
-                "recieved error while refreshing {}: {}",
+                "received error while refreshing {}: {}",
                 program,
                 String::from_utf8(output.stderr)?
             )).into());

--- a/docs/api/router-dashboard.md
+++ b/docs/api/router-dashboard.md
@@ -559,7 +559,7 @@ Format:
       "wg_public_key": "pubkey"
     },
     {
-      "total_payment_recieved": "0x0",
+      "total_payment_received": "0x0",
       "total_payment_sent": "0x0",
       "debt": "0",
       "incoming_payments": "0"

--- a/docs/api/router-dashboard.md
+++ b/docs/api/router-dashboard.md
@@ -534,7 +534,7 @@ Calling HTTP `DELETE` request on this endpoint causes all tables to be wiped out
 
 ## /debts
 
-Calling HTTP `GET` request on this endpoint returns a list of debts. Each element of the resulting list contains a 2-elements array where first elements contains `Identity` data, and second element contains details about the debt owed.
+Calling HTTP `GET` request on this endpoint returns a list of debts. Each element of the resulting list contains a dictionary with two keys: `identity` with a dictionary with identity-related information, and `payment_details` key with a value of payments related informations.
 
 - URL: `<rita ip>:<rita_dashboard_port>/debts`
 - Method: `GET`
@@ -552,19 +552,20 @@ Format:
 
 ```json
 [
-  [
-    {
+  {
+    "identity": {
       "mesh_ip": "a:b:c:d:e:f:g:h",
       "eth_address": "0x0101010101010101010101010101010101010101",
       "wg_public_key": "pubkey"
-    },
-    {
+    }
+    "payment_details": {
       "total_payment_received": "0x0",
       "total_payment_sent": "0x0",
       "debt": "0",
       "incoming_payments": "0"
     }
-  ]
+  },
+  ...
 ]
 ```
 

--- a/docs/api/router-dashboard.md
+++ b/docs/api/router-dashboard.md
@@ -531,3 +531,36 @@ Calling HTTP `DELETE` request on this endpoint causes all tables to be wiped out
 `curl -XDELETE 127.0.0.1:<rita_dashboard_port>/database`
 
 ---
+
+## /debts
+
+Calling HTTP `GET` request on this endpoint returns a list of debts.
+
+- URL: `<rita ip>:<rita_dashboard_port>/debts`
+- Method: `GET`
+- URL Params: `None`
+- Data Params: `None`
+- Success Response:
+  - Code: 200 OK
+  - Contents: `JSON` structured message. See below for an example format.
+- Error Response: `500 Server Error`
+- Sample Call
+
+`curl 127.0..1:<rita_dashboard_port>/debts`
+
+Format:
+```
+[
+ [[mesh_ip,
+   eth_address,
+   wg_public_key],
+  [total_payment_received,
+   total_payment_sent,
+   debt,
+   incoming_payments,
+   debt_buffer]],
+  ...
+]
+```
+
+---

--- a/docs/api/router-dashboard.md
+++ b/docs/api/router-dashboard.md
@@ -534,7 +534,7 @@ Calling HTTP `DELETE` request on this endpoint causes all tables to be wiped out
 
 ## /debts
 
-Calling HTTP `GET` request on this endpoint returns a list of debts.
+Calling HTTP `GET` request on this endpoint returns a list of debts. Each element of the resulting list contains a 2-elements array where first elements contains `Identity` data, and second element contains details about the debt owed.
 
 - URL: `<rita ip>:<rita_dashboard_port>/debts`
 - Method: `GET`
@@ -549,17 +549,22 @@ Calling HTTP `GET` request on this endpoint returns a list of debts.
 `curl 127.0..1:<rita_dashboard_port>/debts`
 
 Format:
-```
+
+```json
 [
- [[mesh_ip,
-   eth_address,
-   wg_public_key],
-  [total_payment_received,
-   total_payment_sent,
-   debt,
-   incoming_payments,
-   debt_buffer]],
-  ...
+  [
+    {
+      "mesh_ip": "a:b:c:d:e:f:g:h",
+      "eth_address": "0x0101010101010101010101010101010101010101",
+      "wg_public_key": "pubkey"
+    },
+    {
+      "total_payment_recieved": "0x0",
+      "total_payment_sent": "0x0",
+      "debt": "0",
+      "incoming_payments": "0"
+    }
+  ]
 ]
 ```
 

--- a/rita/src/client.rs
+++ b/rita/src/client.rs
@@ -227,6 +227,7 @@ fn main() {
             .route("/info", Method::GET, get_own_info)
             .route("/version", Method::GET, version)
             .route("/wipe", Method::POST, wipe)
+            .route("/debts", Method::GET, get_debts)
     }).workers(1)
         .bind(format!(
             "[::0]:{}",

--- a/rita/src/exit.rs
+++ b/rita/src/exit.rs
@@ -236,6 +236,7 @@ fn main() {
             .route("/version", Method::GET, version)
             .route("/wipe", Method::POST, wipe)
             .route("/database", Method::DELETE, nuke_db)
+            .route("/debts", Method::GET, get_debts)
     }).bind(format!(
         "[::0]:{}",
         SETTING.get_network().rita_dashboard_port

--- a/rita/src/rita_client/dashboard/mod.rs
+++ b/rita/src/rita_client/dashboard/mod.rs
@@ -249,7 +249,7 @@ impl Handler<GetNodeInfo> for Dashboard {
                                 output.push(NodeInfo {
                                     nickname: serde_json::to_string(&identity.mesh_ip).unwrap(),
                                     route_metric_to_exit: 0,
-                                    total_payments: debt_info.total_payment_recieved.into(),
+                                    total_payments: debt_info.total_payment_received.into(),
                                     debt: debt_info.debt.clone().into(),
                                     link_cost: 0,
                                     price_to_exit: 0,
@@ -261,7 +261,7 @@ impl Handler<GetNodeInfo> for Dashboard {
                             output.push(NodeInfo {
                                 nickname: serde_json::to_string(&identity.mesh_ip).unwrap(),
                                 route_metric_to_exit: route.metric,
-                                total_payments: debt_info.total_payment_recieved.into(),
+                                total_payments: debt_info.total_payment_received.into(),
                                 debt: debt_info.debt.clone().into(),
                                 link_cost: route.refmetric,
                                 price_to_exit: route.price,
@@ -270,7 +270,7 @@ impl Handler<GetNodeInfo> for Dashboard {
                             output.push(NodeInfo {
                                 nickname: serde_json::to_string(&identity.mesh_ip).unwrap(),
                                 route_metric_to_exit: 0,
-                                total_payments: debt_info.total_payment_recieved.into(),
+                                total_payments: debt_info.total_payment_received.into(),
                                 debt: debt_info.debt.clone().into(),
                                 link_cost: 0,
                                 price_to_exit: 0,

--- a/rita/src/rita_common/dashboard/network_endpoints.rs
+++ b/rita/src/rita_common/dashboard/network_endpoints.rs
@@ -1,4 +1,5 @@
 use actix::registry::SystemService;
+use rita_common::debt_keeper::Dump;
 
 use futures::Future;
 
@@ -14,6 +15,8 @@ use SETTING;
 use super::{Dashboard, GetOwnInfo, OwnInfo};
 use actix_web::*;
 
+use althea_types::Identity;
+use rita_common::debt_keeper::{DebtKeeper, NodeDebtData};
 use rita_common::network_endpoints::JsonStatusResponse;
 
 pub fn get_own_info(_req: HttpRequest) -> Box<Future<Item = Json<OwnInfo>, Error = Error>> {
@@ -98,4 +101,24 @@ pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
     }
 
     Ok(HttpResponse::NoContent().finish())
+}
+
+pub fn get_debts(
+    _req: HttpRequest,
+) -> Box<Future<Item = Json<Vec<(Identity, NodeDebtData)>>, Error = Error>> {
+    trace!("get_debts: Hit");
+    DebtKeeper::from_registry()
+        .send(Dump {})
+        .from_err()
+        .and_then(move |reply| {
+            // Transform a HashMap into a vector of tuple. This way
+            // we can make a simple workaround for the fact that JSON
+            // objects needs strings/numbers as keys.
+            let vec: Vec<(Identity, NodeDebtData)> = reply?
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect();
+            Ok(Json(vec))
+            // Ok(Json(reply?)))
+        }).responder()
 }

--- a/rita/src/rita_common/dashboard/network_endpoints.rs
+++ b/rita/src/rita_common/dashboard/network_endpoints.rs
@@ -1,5 +1,4 @@
 use actix::registry::SystemService;
-use rita_common::debt_keeper::Dump;
 use rita_common::debt_keeper::GetDebtsList;
 
 use futures::Future;
@@ -16,7 +15,6 @@ use SETTING;
 use super::{Dashboard, GetOwnInfo, OwnInfo};
 use actix_web::*;
 
-use althea_types::Identity;
 use rita_common::debt_keeper::{DebtKeeper, GetDebtsResult};
 use rita_common::network_endpoints::JsonStatusResponse;
 

--- a/rita/src/rita_common/debt_keeper/README.md
+++ b/rita/src/rita_common/debt_keeper/README.md
@@ -4,7 +4,7 @@ There are 3 different buckets which credits/debits to a neighboring node is stor
 - Debt buffer
 - Debt
 ## Incoming payments
-Incoming payments represents the payments which a node as recieved from its neighbours. It is
+Incoming payments represents the payments which a node as received from its neighbours. It is
 treated differently from credit from traffic counters as _it will never be sent back to the node
 which sent it_.
 ## Debt buffer
@@ -19,7 +19,7 @@ There are 3 different ways to update the DebtKeeper state:
 - PaymentReceived
 - TrafficUpdate
 - CycleUpdate
-## PaymentRecieved
+## PaymentReceived
 This simply increments the incoming payments value
 ## TrafficUpdate
 Traffic updates are treated differently depending on if the update is positive or negative.
@@ -33,10 +33,10 @@ a DebtAction based on the result of the update
 ### State update
 To update the state, first we pop off the front value of the debt buffer to get a \"time delayed\"
 debt value from several billing cycles ago. 
-Then we check if the PaymentRecieved is enough to pay off the time delayed debt. If there is
+Then we check if the PaymentReceived is enough to pay off the time delayed debt. If there is
 enough, we can also check if there is any Debt to pay off, and try to pay that off with the 
-payments we recieved.
-However, if the PaymentRecieved value is not enough to pay off the time delayed debt, we just
+payments we received.
+However, if the PaymentReceived value is not enough to pay off the time delayed debt, we just
 subtract the difference from the debt.
 ### DebtAction decision
 - If their debt is below our cutoff, suspend the tunnel

--- a/rita/src/rita_common/debt_keeper/mod.rs
+++ b/rita/src/rita_common/debt_keeper/mod.rs
@@ -288,6 +288,41 @@ impl DebtKeeper {
     }
 }
 
+pub struct GetDebtsList;
+
+impl Message for GetDebtsList {
+    type Result = Result<Vec<GetDebtsResult>, Error>;
+}
+
+#[derive(Serialize)]
+pub struct GetDebtsResult {
+    identity: Identity,
+    payment_details: NodeDebtData,
+}
+
+impl GetDebtsResult {
+    pub fn new(identity: &Identity, payment_details: &NodeDebtData) -> GetDebtsResult {
+        GetDebtsResult {
+            identity: identity.clone(),
+            payment_details: payment_details.clone(),
+        }
+    }
+}
+
+impl Handler<GetDebtsList> for DebtKeeper {
+    type Result = Result<Vec<GetDebtsResult>, Error>;
+
+    fn handle(&mut self, _msg: GetDebtsList, _ctx: &mut Context<Self>) -> Self::Result {
+        let debts: Vec<GetDebtsResult> = self
+            .debt_data
+            .iter()
+            .map(|(key, value)| GetDebtsResult::new(&key, &value))
+            .collect();
+        trace!("Debts: {}", debts.len());
+        Ok(debts)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rita/src/rita_common/debt_keeper/mod.rs
+++ b/rita/src/rita_common/debt_keeper/mod.rs
@@ -16,7 +16,7 @@ use failure::Error;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NodeDebtData {
-    pub total_payment_recieved: Uint256,
+    pub total_payment_received: Uint256,
     pub total_payment_sent: Uint256,
     pub debt: Int256,
     pub incoming_payments: Int256,
@@ -30,7 +30,7 @@ pub struct NodeDebtData {
 impl NodeDebtData {
     fn new(buffer_period: u32) -> NodeDebtData {
         NodeDebtData {
-            total_payment_recieved: Uint256::from(0u32),
+            total_payment_received: Uint256::from(0u32),
             total_payment_sent: Uint256::from(0u32),
             debt: Int256::from(0),
             incoming_payments: Int256::from(0),
@@ -176,7 +176,7 @@ impl DebtKeeper {
             old_balance
         );
         debt_data.incoming_payments += amount.clone();
-        debt_data.total_payment_recieved += amount.clone();
+        debt_data.total_payment_received += amount.clone();
 
         trace!(
             "new balance for {:?}: {:?}",
@@ -257,7 +257,7 @@ impl DebtKeeper {
         }
 
         let close_threshold = SETTING.get_payment().close_threshold.clone()
-            - debt_data.total_payment_recieved.clone()
+            - debt_data.total_payment_received.clone()
                 / SETTING.get_payment().close_fraction.clone();
 
         if debt_data.debt < close_threshold {

--- a/rita/src/rita_common/peer_listener/message.rs
+++ b/rita/src/rita_common/peer_listener/message.rs
@@ -94,7 +94,7 @@ impl PeerMessage {
         trace!("Starting ImHere packet decode!");
         // Check if buffer is empty
         if buf.is_empty() {
-            trace!("Recieved an empty ImHere packet!");
+            trace!("Received an empty ImHere packet!");
             return Err(MessageError::InvalidPayloadError);
         }
         let mut pointer = Cursor::new(&buf);
@@ -105,7 +105,7 @@ impl PeerMessage {
                 let packet_size = pointer.read_u16::<BigEndian>()?;
                 if packet_size < MSG_IM_HERE_LEN {
                     trace!(
-                        "Recieved an ImHere packet with an invalid size: {:?}",
+                        "Received an ImHere packet with an invalid size: {:?}",
                         packet_size
                     );
                     return Err(MessageError::BufferUnderflow);
@@ -131,7 +131,7 @@ impl PeerMessage {
                     || peer_address.is_multicast()
                 {
                     trace!(
-                        "Recieved a valid ImHere with an invalid ip address: {:?}",
+                        "Received a valid ImHere with an invalid ip address: {:?}",
                         peer_address,
                     );
                     return Err(MessageError::InvalidIpAddress);
@@ -141,7 +141,7 @@ impl PeerMessage {
                 Ok(PeerMessage::ImHere(peer_address))
             }
             _ => {
-                trace!("Recieved packet with an unknown magic: {:X?}", packet_magic);
+                trace!("Received packet with an unknown magic: {:X?}", packet_magic);
                 return Err(MessageError::InvalidMagic);
             }
         }

--- a/rita/src/rita_common/peer_listener/mod.rs
+++ b/rita/src/rita_common/peer_listener/mod.rs
@@ -268,18 +268,16 @@ fn receive_im_here(
         // this buffer is kept intentionally small to discard larger packets earlier rather than later
         loop {
             let mut datagram: [u8; 100] = [0; 100];
-            let (bytes_read, sock_addr) = match listen_interface
-                .multicast_socket
-                .recv_from(&mut datagram)
-            {
-                Ok(b) => b,
-                Err(e) => {
-                    trace!("Could not recv ImHere: {:?}", e);
-                    // TODO Consider we might want to remove interfaces that produce specific types
-                    // of errors from the active list
-                    break;
-                }
-            };
+            let (bytes_read, sock_addr) =
+                match listen_interface.multicast_socket.recv_from(&mut datagram) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        trace!("Could not recv ImHere: {:?}", e);
+                        // TODO Consider we might want to remove interfaces that produce specific types
+                        // of errors from the active list
+                        break;
+                    }
+                };
             trace!(
                 "Received {} bytes on multicast socket from {:?}",
                 bytes_read,

--- a/rita/src/rita_common/peer_listener/mod.rs
+++ b/rita/src/rita_common/peer_listener/mod.rs
@@ -268,16 +268,18 @@ fn receive_im_here(
         // this buffer is kept intentionally small to discard larger packets earlier rather than later
         loop {
             let mut datagram: [u8; 100] = [0; 100];
-            let (bytes_read, sock_addr) =
-                match listen_interface.multicast_socket.recv_from(&mut datagram) {
-                    Ok(b) => b,
-                    Err(e) => {
-                        trace!("Could not recv ImHere: {:?}", e);
-                        // TODO Consider we might want to remove interfaces that produce specific types
-                        // of errors from the active list
-                        break;
-                    }
-                };
+            let (bytes_read, sock_addr) = match listen_interface
+                .multicast_socket
+                .recv_from(&mut datagram)
+            {
+                Ok(b) => b,
+                Err(e) => {
+                    trace!("Could not recv ImHere: {:?}", e);
+                    // TODO Consider we might want to remove interfaces that produce specific types
+                    // of errors from the active list
+                    break;
+                }
+            };
             trace!(
                 "Received {} bytes on multicast socket from {:?}",
                 bytes_read,


### PR DESCRIPTION
This PR implements debts API. Unfortunately we can't just simply transform `HashMap<K, V>` into a JSON object when `K` is a struct. Because of that this API returns a list of tuples similiar to `Vec<(K, V)>`.

Closes #214 