### PR TITLE
Fix actix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,9 +1,9 @@
 [[package]]
 name = "actix"
-version = "0.7.0"
-source = "git+https://github.com/kingoflolz/actix.git?branch=althea-mesh#24128214460d911943a06b87028810cae5011774"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "actix_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -28,15 +28,15 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "0.7.0"
-source = "git+https://github.com/actix/actix-web.git?branch=fix-missing-content-length#d9988f3ab68ad074b7367354419bb2ac582f20c0"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "actix 0.7.0 (git+https://github.com/kingoflolz/actix.git?branch=althea-mesh)",
+ "actix 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "cookie 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -60,7 +60,7 @@ dependencies = [
  "regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_urlencoded 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_urlencoded 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -71,17 +71,6 @@ dependencies = [
  "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "actix_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -139,7 +128,7 @@ dependencies = [
 name = "althea_types"
 version = "0.1.0"
 dependencies = [
- "actix 0.7.0 (git+https://github.com/kingoflolz/actix.git?branch=althea-mesh)",
+ "actix 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.3.3 (git+https://github.com/paritytech/primitives.git)",
  "eui48 0.4.0 (git+https://github.com/althea-mesh/eui48)",
@@ -470,7 +459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cookie"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1963,7 +1952,7 @@ dependencies = [
  "native-tls 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_urlencoded 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_urlencoded 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1983,8 +1972,8 @@ dependencies = [
 name = "rita"
 version = "0.1.5"
 dependencies = [
- "actix 0.7.0 (git+https://github.com/kingoflolz/actix.git?branch=althea-mesh)",
- "actix-web 0.7.0 (git+https://github.com/actix/actix-web.git?branch=fix-missing-content-length)",
+ "actix 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-web 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "althea_kernel_interface 0.1.0",
  "althea_types 0.1.0",
@@ -2222,7 +2211,7 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2298,8 +2287,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "stats_server"
 version = "0.1.0"
 dependencies = [
- "actix 0.7.0 (git+https://github.com/kingoflolz/actix.git?branch=althea-mesh)",
- "actix-web 0.7.0 (git+https://github.com/actix/actix-web.git?branch=fix-missing-content-length)",
+ "actix 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-web 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "althea_types 0.1.0",
  "docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2909,9 +2898,8 @@ dependencies = [
 ]
 
 [metadata]
-"checksum actix 0.7.0 (git+https://github.com/kingoflolz/actix.git?branch=althea-mesh)" = "<none>"
-"checksum actix-web 0.7.0 (git+https://github.com/actix/actix-web.git?branch=fix-missing-content-length)" = "<none>"
-"checksum actix_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c4b1dc922654b9aca7a8a31eab875fde804fa9fbd67f220f2e457787b23590f2"
+"checksum actix 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "79ad2aaef6647ec755ad4e6581e578694fda752c021bde3e0dd7f1174e25e74a"
+"checksum actix-web 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d0eddc44f25a168d776edf60477bd3d46566f89286e66288da8e196072e5a870"
 "checksum actix_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b9d1525ef45e5e021f0b93dace157dcab5d792acb4cc78f3213787d65e2bb92"
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
@@ -2948,7 +2936,7 @@ dependencies = [
 "checksum colored 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc0a60679001b62fb628c4da80e574b9645ab4646056d7c9018885efffe45533"
 "checksum config 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5379dd8b3e7f488a31107d2c9586ce2ddbee2bc839201b3b38dbdf550351c1e"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
-"checksum cookie 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "746858cae4eae40fff37e1998320068df317bc247dc91a67c6cfa053afdc2abb"
+"checksum cookie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1465f8134efa296b4c19db34d909637cb2bf0f7aaf21299e23e18fa29ac557cf"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
@@ -3139,7 +3127,7 @@ dependencies = [
 "checksum serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)" = "3525a779832b08693031b8ecfb0de81cd71cfd3812088fafe9a7496789572124"
 "checksum serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c6908c7b925cd6c590358a4034de93dbddb20c45e1d021931459fd419bf0e2"
 "checksum serde_test 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5"
-"checksum serde_urlencoded 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e703cef904312097cfceab9ce131ff6bbe09e8c964a0703345a5f49238757bc1"
+"checksum serde_urlencoded 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "aaed41d9fb1e2f587201b863356590c90c1157495d811430a0c0325fe8169650"
 "checksum sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,4 @@ codegen-units = 1
 incremental = false
 
 [patch.crates-io]
-actix = { git = "https://github.com/kingoflolz/actix.git", branch = "althea-mesh" }
-actix-web = { git = "https://github.com/actix/actix-web.git", branch = "fix-missing-content-length" }
 trust-dns-resolver = { git = "https://github.com/kingoflolz/trust-dns.git", branch = "lower-max-ttl" }

--- a/althea_types/Cargo.toml
+++ b/althea_types/Cargo.toml
@@ -11,5 +11,5 @@ serde = "1.0.70"
 serde_json = "1.0.24"
 hex = "0.3.2"
 eui48 = { git = "https://github.com/althea-mesh/eui48", features = ["serde"] }
-actix = { git = "https://github.com/kingoflolz/actix", branch = "althea-mesh", optional=true}
+actix = { version = "0.7.4", optional = true}
 ethereum-types = {git="https://github.com/paritytech/primitives.git"}

--- a/rita/Cargo.toml
+++ b/rita/Cargo.toml
@@ -27,8 +27,8 @@ exit_db = { path = "../exit_db" }
 num256 = { path = "../num256" }
 settings = { path = "../settings" }
 
-actix = { git = "https://github.com/kingoflolz/actix", branch = "althea-mesh"}
-actix-web = { git = "https://github.com/actix/actix-web", default-features = false, branch = "fix-missing-content-length"}
+actix = "0.7.4"
+actix-web = { version = "0.7.4", default_features = false }
 actix_derive = "0.3.0"
 bytes = "0.4.9"
 clippy = { version = "0.0.212", optional = true }

--- a/stats_server/Cargo.toml
+++ b/stats_server/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 authors = ["kingoflolz <wangben3@gmail.com>"]
 
 [dependencies]
-actix = { git = "https://github.com/kingoflolz/actix", branch = "althea-mesh"}
-actix-web = { git = "https://github.com/actix/actix-web", default-features = false, branch = "fix-missing-content-length"}
+actix = "0.7.4"
+actix-web = { version = "0.7.4", default-features = false }
 serde = "1.0.70"
 serde_derive = "1.0.70"
 serde_json = "1.0.24"


### PR DESCRIPTION
All upstream stuff has been merged and released, we can now simply use cargo versions. 

resolves #217 