### PR TITLE
Use ethereum-types 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ version = "0.1.0"
 dependencies = [
  "actix 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types 0.3.3 (git+https://github.com/paritytech/primitives.git)",
+ "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "eui48 0.4.0 (git+https://github.com/althea-mesh/eui48)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num256 0.1.0",
@@ -773,34 +773,34 @@ dependencies = [
 
 [[package]]
 name = "ethbloom"
-version = "0.5.1"
-source = "git+https://github.com/paritytech/primitives.git#19c1d38627676cc9c51a24d3388c6fdb3b2264b2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types-serialize 0.2.1 (git+https://github.com/paritytech/primitives.git)",
- "fixed-hash 0.2.1 (git+https://github.com/paritytech/primitives.git)",
+ "ethereum-types-serialize 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixed-hash 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ethereum-types"
-version = "0.3.3"
-source = "git+https://github.com/paritytech/primitives.git#19c1d38627676cc9c51a24d3388c6fdb3b2264b2"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethbloom 0.5.1 (git+https://github.com/paritytech/primitives.git)",
- "ethereum-types-serialize 0.2.1 (git+https://github.com/paritytech/primitives.git)",
- "fixed-hash 0.2.1 (git+https://github.com/paritytech/primitives.git)",
+ "ethbloom 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum-types-serialize 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixed-hash 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "uint 0.2.1 (git+https://github.com/paritytech/primitives.git)",
+ "uint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ethereum-types-serialize"
 version = "0.2.1"
-source = "git+https://github.com/paritytech/primitives.git#19c1d38627676cc9c51a24d3388c6fdb3b2264b2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -860,8 +860,8 @@ dependencies = [
 
 [[package]]
 name = "fixed-hash"
-version = "0.2.1"
-source = "git+https://github.com/paritytech/primitives.git#19c1d38627676cc9c51a24d3388c6fdb3b2264b2"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1600,7 +1600,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "num256"
 version = "0.1.0"
 dependencies = [
- "ethereum-types 0.3.3 (git+https://github.com/paritytech/primitives.git)",
+ "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2679,7 +2679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "uint"
 version = "0.2.1"
-source = "git+https://github.com/paritytech/primitives.git#19c1d38627676cc9c51a24d3388c6fdb3b2264b2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2972,14 +2972,14 @@ dependencies = [
 "checksum error-chain 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faa976b4fd2e4c2b2f3f486874b19e61944d3de3de8b61c9fcf835d583871bcc"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6930e04918388a9a2e41d518c25cf679ccafe26733fb4127dbf21993f2575d46"
-"checksum ethbloom 0.5.1 (git+https://github.com/paritytech/primitives.git)" = "<none>"
-"checksum ethereum-types 0.3.3 (git+https://github.com/paritytech/primitives.git)" = "<none>"
-"checksum ethereum-types-serialize 0.2.1 (git+https://github.com/paritytech/primitives.git)" = "<none>"
+"checksum ethbloom 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a93a43ce2e9f09071449da36bfa7a1b20b950ee344b6904ff23de493b03b386"
+"checksum ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c48729b8aea8aedb12cf4cb2e5cef439fdfe2dda4a89e47eeebd15778ef53b6"
+"checksum ethereum-types-serialize 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ac59a21a9ce98e188f3dace9eb67a6c4a3c67ec7fbc7218cb827852679dc002"
 "checksum eui48 0.4.0 (git+https://github.com/althea-mesh/eui48)" = "<none>"
 "checksum failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7efb22686e4a466b1ec1a15c2898f91fa9cb340452496dca654032de20ff95b9"
 "checksum failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "946d0e98a50d9831f5d589038d2ca7f8f455b1c21028c0db0e84116a12696426"
 "checksum filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "714653f3e34871534de23771ac7b26e999651a0a228f47beb324dfdf1dd4b10f"
-"checksum fixed-hash 0.2.1 (git+https://github.com/paritytech/primitives.git)" = "<none>"
+"checksum fixed-hash 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d5ec8112f00ea8a483e04748a85522184418fd1cf02890b626d8fc28683f7de"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
@@ -3172,7 +3172,7 @@ dependencies = [
 "checksum twoway 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
-"checksum uint 0.2.1 (git+https://github.com/paritytech/primitives.git)" = "<none>"
+"checksum uint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "38051a96565903d81c9a9210ce11076b2218f3b352926baa1f5f6abbdfce8273"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284b6d3db520d67fbe88fd778c21510d1b0ba4a551e5d0fbb023d33405f6de8a"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"

--- a/althea_types/Cargo.toml
+++ b/althea_types/Cargo.toml
@@ -12,4 +12,4 @@ serde_json = "1.0.24"
 hex = "0.3.2"
 eui48 = { git = "https://github.com/althea-mesh/eui48", features = ["serde"] }
 actix = { version = "0.7.4", optional = true}
-ethereum-types = {git="https://github.com/paritytech/primitives.git"}
+ethereum-types = "0.3.2"

--- a/num256/Cargo.toml
+++ b/num256/Cargo.toml
@@ -10,4 +10,4 @@ serde = "1.0.70"
 serde_derive = "1.0.70"
 serde_json = "1.0.24"
 lazy_static = "1.0.2"
-ethereum-types = {git="https://github.com/paritytech/primitives.git"}
+ethereum-types = "0.3.2"

--- a/num256/src/lib.rs
+++ b/num256/src/lib.rs
@@ -420,92 +420,41 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn test_uint_add_assign_panic() {
-        let mut big = BIGGEST_UINT.clone();
-        big += Uint256::from(1 as u32);
-    }
-
-    #[test]
-    fn test_uint_add_assign_no_panic() {
-        let mut big = BIGGEST_UINT.clone();
-        big += Uint256::from(0 as u32);
-    }
-
-    #[test]
-    #[should_panic]
     fn test_uint_from_add_panic() {
-        let _val = BIGGEST_UINT.clone() + 1;
+        let _val = BIGGEST_UINT.clone().add(Uint256::from(1));
     }
 
     #[test]
     fn test_uint_from_add_no_panic() {
-        let _val = BIGGEST_UINT.clone() + 0;
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_uint_from_add_assign_panic() {
-        let mut big = BIGGEST_UINT.clone();
-        big += Uint256::from(1);
-    }
-
-    #[test]
-    fn test_uint_from_add_assign_no_panic() {
-        let mut big = BIGGEST_UINT.clone();
-        big += Uint256::from(0);
+        let _val = BIGGEST_UINT.clone().add(Uint256::from(0));
     }
 
     #[test]
     #[should_panic]
     fn test_uint_sub_panic() {
-        let _val = Uint256::from(1 as u32) - Uint256::from(2 as u32);
+        let _val = Uint256::from(1 as u32).sub(Uint256::from(2 as u32));
     }
 
     #[test]
     fn test_uint_sub_no_panic() {
         assert_eq!(
-            Uint256::from(1 as u32) - Uint256::from(1 as u32),
+            Uint256::from(1 as u32).sub(Uint256::from(1 as u32)),
             Uint256::from(0 as u32)
         );
     }
 
     #[test]
     #[should_panic]
-    fn test_uint_sub_assign_panic() {
-        let mut small = Uint256::from(1 as u32);
-        small -= Uint256::from(2);
-    }
-
-    #[test]
-    fn test_uint_sub_assign_no_panic() {
-        let mut small = Uint256::from(1 as u32);
-        small -= Uint256::from(1);
-        assert_eq!(small, Uint256::from(0 as u32));
-    }
-
-    #[test]
-    fn test_uint_from_sub_assign_no_panic() {
-        let mut small = Uint256::from(1 as u32);
-        small -= 1.into();
-        assert_eq!(small, Uint256::from(0 as u32));
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_uint_from_sub_assign_panic() {
-        let mut small = Uint256::from(1 as u32);
-        small -= 2.into();
-    }
-
-    #[test]
-    #[should_panic]
     fn test_uint_from_sub_panic() {
-        let _val = Uint256::from(1 as u32) - 2;
+        let _val = Uint256::from(1 as u32).sub(Uint256::from(2));
     }
 
     #[test]
     fn test_uint_from_sub_no_panic() {
-        assert_eq!(Uint256::from(1 as u32) - 1, Uint256::from(0 as u32));
+        assert_eq!(
+            Uint256::from(1 as u32).sub(Uint256::from(1)),
+            Uint256::from(0 as u32)
+        );
     }
 
     #[test]
@@ -521,20 +470,6 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn test_uint_mul_assign_panic() {
-        let mut big = BIGGEST_UINT.clone();
-        big *= Uint256::from(2);
-    }
-
-    #[test]
-    fn test_uint_mul_assign_no_panic() {
-        let mut num = Uint256::from(3);
-        num *= Uint256::from(2);
-        assert_eq!(num, Uint256::from(6));
-    }
-
-    #[test]
-    #[should_panic]
     fn test_uint_from_mul_panic() {
         let _val = BIGGEST_UINT.clone() * Uint256::from(2);
     }
@@ -542,20 +477,6 @@ mod tests {
     #[test]
     fn test_uint_from_mul_no_panic() {
         assert_eq!(Uint256::from(3) * Uint256::from(2), Uint256::from(6));
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_uint_from_mul_assign_panic() {
-        let mut big = BIGGEST_UINT.clone();
-        big *= Uint256::from(2);
-    }
-
-    #[test]
-    fn test_uint_from_mul_assign_no_panic() {
-        let mut num = Uint256::from(3);
-        num *= Uint256::from(2);
-        assert_eq!(num, Uint256::from(6));
     }
 
     #[test]
@@ -570,33 +491,19 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn test_uint_div_assign_panic() {
-        let mut big = BIGGEST_UINT.clone();
-        big /= Uint256::from(0);
-    }
-
-    #[test]
     fn test_uint_from_div_assign_no_panic() {
-        assert_eq!(Uint256::from(6) / 2, Uint256::from(3));
+        assert_eq!(Uint256::from(6).div(Uint256::from(2)), Uint256::from(3));
     }
 
     #[test]
     #[should_panic]
     fn test_uint_from_div_panic() {
-        let _val = BIGGEST_UINT.clone() / 0;
+        let _val = BIGGEST_UINT.clone().div(Uint256::from(0));
     }
 
     #[test]
     fn test_uint_from_div_no_panic() {
-        assert_eq!(Uint256::from(6) / 2, Uint256::from(3));
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_uint_from_div_assign_panic() {
-        let mut big = BIGGEST_UINT.clone();
-        big /= 0;
+        assert_eq!(Uint256::from(6).div(Uint256::from(2)), Uint256::from(3));
     }
 
     #[test]

--- a/num256/src/lib.rs
+++ b/num256/src/lib.rs
@@ -7,6 +7,7 @@ use num::bigint::{BigInt, BigUint, ToBigInt};
 use num::traits::ops::checked::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
 use num::traits::Signed;
 use num::ToPrimitive;
+use num::Zero;
 use serde::ser::Serialize;
 use serde::{Deserialize, Deserializer, Serializer};
 use std::fmt;
@@ -27,6 +28,10 @@ pub struct Int256(BigInt);
 impl Int256 {
     pub fn abs(&self) -> Self {
         Int256(self.clone().0.abs())
+    }
+
+    pub fn zero() -> Self {
+        Int256(BigInt::zero())
     }
 }
 


### PR DESCRIPTION
This removes operators which are part of 0.4. In guac we ingest eth-types 0.4 too (althea_types) but also eth-types 0.3 (ethabi). This isn't easily replacable, so probably going back to 0.3 everywhere is safest thing to do.

I tried two approaches:

- Remove num256 and use BigInt/BigUint directly. Ran into custom serialization issue for backwards compatibility (default BigInt/BigUint serialization produces array of array bytes and we keep big nums as string, big unsinged nums as hexadecimal etc.). Kinda works, but needs more effort to figure out failing test cases.
- Make Uint256 a wrapper too, possibly implementing operators and make it look like a type (just like Int256). Probably the best way to go, just need some effort to write all traits to make Int256/Uint256 usable like normal numbers (and there are a lot of them)

This debt should be paid at some point, possibly could be done as part of #25.

And of course this will move forward #236 