### PR TITLE
rita: Delete tunnels after a timeout

### DIFF
--- a/settings/src/lib.rs
+++ b/settings/src/lib.rs
@@ -71,6 +71,10 @@ fn default_discovery_ip() -> Ipv6Addr {
     Ipv6Addr::new(0xff02, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x8)
 }
 
+fn default_tunnel_timeout() -> u64 {
+    900 // 15 minutes
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct NetworkSettings {
     /// Our own mesh IP (in fd00::/8)
@@ -121,6 +125,9 @@ pub struct NetworkSettings {
     /// This in memory variable specifies if we are a gateway or not
     #[serde(skip_deserializing, default)]
     pub is_gateway: bool,
+    /// How long do we wait without contact from a peer before we delete the associated tunnel?
+    #[serde(default = "default_tunnel_timeout")]
+    pub tunnel_timeout_seconds: u64,
 }
 
 impl Default for NetworkSettings {
@@ -128,7 +135,7 @@ impl Default for NetworkSettings {
         NetworkSettings {
             own_ip: "fd00::1".parse().unwrap(),
             bounty_ip: "fd00::3".parse().unwrap(),
-            discovery_ip: Ipv6Addr::new(0xff02, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x8),
+            discovery_ip: default_discovery_ip(),
             babel_port: 6872,
             rita_hello_port: 4876,
             rita_dashboard_port: 4877,
@@ -144,6 +151,7 @@ impl Default for NetworkSettings {
             external_nic: None,
             default_route: Vec::new(),
             is_gateway: false,
+            tunnel_timeout_seconds: default_tunnel_timeout(),
         }
     }
 }


### PR DESCRIPTION
This commit adds a last_contact field to the Tunnel struct which keeps
track of the last point in time when we heard from or successfuly
hollered at a neighbor. On every such occasion we bump last_contact to
Instant::now().

Concordantly, the common rita_loop will send a new TriggerGC message to
TunnelManager containing the timeout to check open tunnels against. The
TriggerGC handler will iterate over all open tunnel entries and discard
those which exceed the passed timeout duration along with the underlying
wgN interfaces and ports.

rita/src/rita_common/rita_loop/mod.rs:
* Send a TriggerGC message to TunnelManager every tick

rita/src/rita_common/tunnel_manager/mod.rs:
* Add a last_contact field (std::time::Instant) to the Tunnel struct;
  Instant::now() is the default value.
* Bump the last_contact field in open_tunnel() whenever we have a
  tunnel; move some ifs around - the logic's implications stay the same.
* Add a TriggerGC message which goes over all tunnels and discards those
  which were last contacted longer ago than a passed std::time::Duration
  value.