### PR TITLE
Divide the balance to ETH.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,6 +2001,7 @@ dependencies = [
  "minihttpse 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockstream 0.0.3 (git+https://github.com/lazy-bitfield/rust-mockstream.git)",
+ "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num256 0.1.0",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rita/Cargo.toml
+++ b/rita/Cargo.toml
@@ -62,3 +62,4 @@ trust-dns-resolver = "0.9.0"
 handlebars = "1.0.0"
 byteorder = { version = "1.2.4", features = ["i128"] }
 openssl-probe = "0.1.2"
+num-traits="0.2"

--- a/rita/src/client.rs
+++ b/rita/src/client.rs
@@ -35,6 +35,7 @@ extern crate ipnetwork;
 extern crate lettre;
 extern crate lettre_email;
 extern crate minihttpse;
+extern crate num_traits;
 extern crate openssl_probe;
 extern crate rand;
 extern crate regex;

--- a/rita/src/exit.rs
+++ b/rita/src/exit.rs
@@ -39,6 +39,7 @@ extern crate ipnetwork;
 extern crate lettre;
 extern crate lettre_email;
 extern crate minihttpse;
+extern crate num_traits;
 extern crate openssl_probe;
 extern crate rand;
 extern crate regex;

--- a/rita/src/rita_common/dashboard/mod.rs
+++ b/rita/src/rita_common/dashboard/mod.rs
@@ -31,10 +31,10 @@ impl Default for Dashboard {
 
 #[derive(Debug, Fail)]
 enum OwnInfoError {
-    #[fail(display = "Unable to divide {}", _0)]
-    DivisionError(Int256),
-    #[fail(display = "Unable to downcast value {}", _0)]
-    CastError(Int256),
+    #[fail(display = "Unable to round balance of {} down to 1 ETH", _0)]
+    RoundDownError(Int256),
+    #[fail(display = "Unable to downcast value {} to signed 64 bits", _0)]
+    DownCastError(Int256),
 }
 
 #[derive(Serialize)]
@@ -61,9 +61,11 @@ impl Handler<GetOwnInfo> for Dashboard {
                     Ok(balance) => {
                         let balance = balance
                             .checked_div(&Int256::from(1_000_000_000i64))
-                            .ok_or(OwnInfoError::DivisionError(balance.clone()))?;
+                            .ok_or(OwnInfoError::RoundDownError(balance.clone()))?;
                         Ok(OwnInfo {
-                            balance: balance.to_i64().ok_or(OwnInfoError::CastError(balance))?,
+                            balance: balance
+                                .to_i64()
+                                .ok_or(OwnInfoError::DownCastError(balance))?,
                             version: env!("CARGO_PKG_VERSION").to_string(),
                         })
                     }

--- a/rita/src/rita_common/dashboard/mod.rs
+++ b/rita/src/rita_common/dashboard/mod.rs
@@ -59,13 +59,9 @@ impl Handler<GetOwnInfo> for Dashboard {
                 .from_err()
                 .and_then(|own_balance| match own_balance {
                     Ok(balance) => {
-                        let balance = if balance > Int256::zero() {
-                            balance
-                                .checked_div(&Int256::from(1_000_000_000i64))
-                                .ok_or(OwnInfoError::DivisionError(balance.clone()))?
-                        } else {
-                            Int256::zero()
-                        };
+                        let balance = balance
+                            .checked_div(&Int256::from(1_000_000_000i64))
+                            .ok_or(OwnInfoError::DivisionError(balance.clone()))?;
                         Ok(OwnInfo {
                             balance: balance.to_i64().ok_or(OwnInfoError::CastError(balance))?,
                             version: env!("CARGO_PKG_VERSION").to_string(),

--- a/rita/src/rita_common/dashboard/mod.rs
+++ b/rita/src/rita_common/dashboard/mod.rs
@@ -5,8 +5,11 @@ use futures::Future;
 
 use rita_common::payment_controller::{GetOwnBalance, PaymentController};
 
-pub mod network_endpoints;
+use num256::Int256;
 
+pub mod network_endpoints;
+use num_traits::ops::checked::CheckedDiv;
+use num_traits::ToPrimitive;
 pub struct Dashboard;
 
 impl Actor for Dashboard {
@@ -24,6 +27,14 @@ impl Default for Dashboard {
     fn default() -> Dashboard {
         Dashboard {}
     }
+}
+
+#[derive(Debug, Fail)]
+enum OwnInfoError {
+    #[fail(display = "Unable to divide {}", _0)]
+    DivisionError(Int256),
+    #[fail(display = "Unable to downcast value {}", _0)]
+    CastError(Int256),
 }
 
 #[derive(Serialize)]
@@ -47,10 +58,19 @@ impl Handler<GetOwnInfo> for Dashboard {
                 .send(GetOwnBalance {})
                 .from_err()
                 .and_then(|own_balance| match own_balance {
-                    Ok(balance) => Ok(OwnInfo {
-                        balance: balance,
-                        version: env!("CARGO_PKG_VERSION").to_string(),
-                    }),
+                    Ok(balance) => {
+                        let balance = if balance > Int256::zero() {
+                            balance
+                                .checked_div(&Int256::from(1_000_000_000i64))
+                                .ok_or(OwnInfoError::DivisionError(balance.clone()))?
+                        } else {
+                            Int256::zero()
+                        };
+                        Ok(OwnInfo {
+                            balance: balance.to_i64().ok_or(OwnInfoError::CastError(balance))?,
+                            version: env!("CARGO_PKG_VERSION").to_string(),
+                        })
+                    }
                     Err(e) => Err(e),
                 }),
         )

--- a/rita/src/rita_common/payment_controller/mod.rs
+++ b/rita/src/rita_common/payment_controller/mod.rs
@@ -90,13 +90,13 @@ impl Handler<PaymentControllerUpdate> for PaymentController {
 pub struct GetOwnBalance;
 
 impl Message for GetOwnBalance {
-    type Result = Result<i64, Error>;
+    type Result = Result<Int256, Error>;
 }
 
 impl Handler<GetOwnBalance> for PaymentController {
-    type Result = Result<i64, Error>;
+    type Result = Result<Int256, Error>;
     fn handle(&mut self, _msg: GetOwnBalance, _: &mut Context<Self>) -> Self::Result {
-        Ok(self.balance.clone().into())
+        Ok(self.balance.clone())
     }
 }
 


### PR DESCRIPTION
Added a lot of safety i.e.  do a checked divide by 10^9 first, and later do a checked downcast. In case of problems it should result in HTTP 500 instead of a panic.

Caution: Balance less than 10^9 would display 0.

Closes #244 