### PR TITLE
Improve logging for exits

### DIFF
--- a/althea_kernel_interface/src/counter.rs
+++ b/althea_kernel_interface/src/counter.rs
@@ -68,9 +68,9 @@ fn test_filter_table_table() {
 
 fn parse_ipset(input: &str) -> Result<HashMap<(IpAddr, String), u64>, Error> {
     lazy_static! {
-        static ref RE: Regex = Regex::new(
-            r"(?m)^add \S+ ([a-f0-9:]+),(wg\d+) packets (\d+) bytes (\d+)"
-        ).expect("Unable to compile regular expression");
+        static ref RE: Regex =
+            Regex::new(r"(?m)^add \S+ ([a-f0-9:]+),(wg\d+) packets (\d+) bytes (\d+)")
+                .expect("Unable to compile regular expression");
     }
     let mut map = HashMap::new();
 
@@ -301,8 +301,7 @@ fn test_read_counters() {
                 Ok(Output {
                     stdout: b"
 add xxx fd00::dead:beef,wg42 packets 111 bytes 222
-"
-                        .to_vec(),
+".to_vec(),
                     stderr: b"".to_vec(),
                     status: ExitStatus::from_raw(0),
                 })
@@ -328,7 +327,6 @@ add xxx fd00::dead:beef,wg42 packets 111 bytes 222
         .get(&(
             IpAddr::V6(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0xdead, 0xbeef)),
             "wg42".into(),
-        ))
-        .expect("Unable to find key");
+        )).expect("Unable to find key");
     assert_eq!(value, &(222u64 + 111u64 * 40));
 }

--- a/althea_kernel_interface/src/exit_server_counter.rs
+++ b/althea_kernel_interface/src/exit_server_counter.rs
@@ -64,9 +64,9 @@ fn test_exit_filter_target_output() {
 
 fn parse_exit_ipset(input: &str) -> Result<HashMap<IpAddr, u64>, Error> {
     lazy_static! {
-        static ref RE: Regex = Regex::new(
-            r"(?m)^add \S+ (fd00::[a-f0-9:]+) packets (\d+) bytes (\d+)"
-        ).expect("Unable to compile regular expression");
+        static ref RE: Regex =
+            Regex::new(r"(?m)^add \S+ (fd00::[a-f0-9:]+) packets (\d+) bytes (\d+)")
+                .expect("Unable to compile regular expression");
     }
     let mut map = HashMap::new();
 
@@ -301,8 +301,7 @@ fn test_read_exit_server_counters() {
                 Ok(Output {
                     stdout: b"
 add asdf fd00::dead:beef packets 100 bytes 200
-"
-                        .to_vec(),
+".to_vec(),
                     stderr: b"".to_vec(),
                     status: ExitStatus::from_raw(0),
                 })
@@ -327,7 +326,6 @@ add asdf fd00::dead:beef packets 100 bytes 200
     let value = result
         .get(&IpAddr::V6(Ipv6Addr::new(
             0xfd00, 0, 0, 0, 0, 0, 0xdead, 0xbeef,
-        )))
-        .expect("Unable to find key");
+        ))).expect("Unable to find key");
     assert_eq!(value, &(200u64 + 100u64 * 80));
 }

--- a/althea_kernel_interface/src/interface_tools.rs
+++ b/althea_kernel_interface/src/interface_tools.rs
@@ -123,8 +123,7 @@ fn test_get_wg_remote_ip() {
         assert_eq!(args, &["show", "wg0", "endpoints"]);
         Ok(Output {
             stdout: b"fvLYbeMV+RYbzJEc4lNEPuK8ulva/5wcSJBz0W5t3hM=	71.8.186.226:60000\
-"
-                .to_vec(),
+".to_vec(),
             stderr: b"".to_vec(),
             status: ExitStatus::from_raw(0),
         })

--- a/althea_types/src/lib.rs
+++ b/althea_types/src/lib.rs
@@ -15,7 +15,7 @@ extern crate actix;
 pub mod interop;
 pub mod rtt;
 
-pub use ethereum_types::{Address, H160, Public, Secret, Signature, U256};
+pub use ethereum_types::{Address, Public, Secret, Signature, H160, U256};
 
 pub use interop::*;
 pub use rtt::RTTimestamps;

--- a/bounty_hunter/src/main.rs
+++ b/bounty_hunter/src/main.rs
@@ -1,4 +1,7 @@
-#![cfg_attr(feature = "system_alloc", feature(alloc_system, global_allocator, allocator_api))]
+#![cfg_attr(
+    feature = "system_alloc",
+    feature(alloc_system, global_allocator, allocator_api)
+)]
 
 #[cfg(feature = "system_alloc")]
 extern crate alloc_system;

--- a/rita/src/client.rs
+++ b/rita/src/client.rs
@@ -7,7 +7,10 @@
 //! This file initilizes the dashboard endpoints for the client as well as the common and client
 //! specific actors.
 
-#![cfg_attr(feature = "system_alloc", feature(alloc_system, allocator_api))]
+#![cfg_attr(
+    feature = "system_alloc",
+    feature(alloc_system, allocator_api)
+)]
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
@@ -208,10 +211,10 @@ fn main() {
             r.method(Method::POST).with(make_payments)
         })
     }).workers(1)
-        .bind(format!("[::0]:{}", SETTING.get_network().rita_contact_port))
-        .unwrap()
-        .shutdown_timeout(0)
-        .start();
+    .bind(format!("[::0]:{}", SETTING.get_network().rita_contact_port))
+    .unwrap()
+    .shutdown_timeout(0)
+    .start();
 
     // dashboard
     server::new(|| {
@@ -233,8 +236,7 @@ fn main() {
                 "/exits/{name}/verify/{code}",
                 Method::POST,
                 verify_on_exit_with_code,
-            )
-            .route("/info", Method::GET, get_own_info)
+            ).route("/info", Method::GET, get_own_info)
             .route("/version", Method::GET, version)
             .route("/wipe", Method::POST, wipe)
             .route("/debts", Method::GET, get_debts)
@@ -246,13 +248,12 @@ fn main() {
                 remove_from_dao_list,
             )
     }).workers(1)
-        .bind(format!(
-            "[::0]:{}",
-            SETTING.get_network().rita_dashboard_port
-        ))
-        .unwrap()
-        .shutdown_timeout(0)
-        .start();
+    .bind(format!(
+        "[::0]:{}",
+        SETTING.get_network().rita_dashboard_port
+    )).unwrap()
+    .shutdown_timeout(0)
+    .start();
 
     let common = rita_common::rita_loop::RitaLoop::new();
     let _: Addr<_> = common.start();

--- a/rita/src/exit.rs
+++ b/rita/src/exit.rs
@@ -9,7 +9,10 @@
 //! This file initilizes the dashboard endpoints for the exit as well as the common and exit
 //! specific actors.
 
-#![cfg_attr(feature = "system_alloc", feature(alloc_system, allocator_api))]
+#![cfg_attr(
+    feature = "system_alloc",
+    feature(alloc_system, allocator_api)
+)]
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
@@ -210,10 +213,10 @@ fn main() {
             r.method(Method::POST).with(make_payments)
         })
     }).workers(1)
-        .bind(format!("[::0]:{}", SETTING.get_network().rita_contact_port))
-        .unwrap()
-        .shutdown_timeout(0)
-        .start();
+    .bind(format!("[::0]:{}", SETTING.get_network().rita_contact_port))
+    .unwrap()
+    .shutdown_timeout(0)
+    .start();
 
     // Exit stuff
     server::new(|| {
@@ -221,19 +224,16 @@ fn main() {
             .resource("/setup", |r| r.method(Method::POST).with(setup_request))
             .resource("/status", |r| {
                 r.method(Method::POST).with_async(status_request)
-            })
-            .resource("/list", |r| r.method(Method::POST).with(list_clients))
+            }).resource("/list", |r| r.method(Method::POST).with(list_clients))
             .resource("/exit_info", |r| {
                 r.method(Method::GET).with(get_exit_info_http)
-            })
-            .resource("/rtt", |r| r.method(Method::GET).with(rtt))
+            }).resource("/rtt", |r| r.method(Method::GET).with(rtt))
     }).bind(format!(
         "[::0]:{}",
         SETTING.get_exit_network().exit_hello_port
-    ))
-        .unwrap()
-        .shutdown_timeout(0)
-        .start();
+    )).unwrap()
+    .shutdown_timeout(0)
+    .start();
 
     // Dashboard
     server::new(|| {
@@ -259,10 +259,9 @@ fn main() {
     }).bind(format!(
         "[::0]:{}",
         SETTING.get_network().rita_dashboard_port
-    ))
-        .unwrap()
-        .shutdown_timeout(0)
-        .start();
+    )).unwrap()
+    .shutdown_timeout(0)
+    .start();
 
     let common = rita_common::rita_loop::RitaLoop::new();
     let _: Addr<_> = common.start();

--- a/rita/src/rita_client/traffic_watcher/mod.rs
+++ b/rita/src/rita_client/traffic_watcher/mod.rs
@@ -118,8 +118,7 @@ pub fn watch<T: Read + Write>(
                         ));
                     }
                 }
-            ))
-            .send()?
+            )).send()?
             .json()?;
         let client_rx = SystemTime::now();
 

--- a/rita/src/rita_common/dao_manager/mod.rs
+++ b/rita/src/rita_common/dao_manager/mod.rs
@@ -315,8 +315,7 @@ fn get_membership(dao_address: EthAddress, target: Identity) -> () {
                         }
                     }
                 })
-        })
-        .then(|_err| Ok(()));
+        }).then(|_err| Ok(()));
     Arbiter::spawn(res);
 }
 

--- a/rita/src/rita_common/dashboard/mod.rs
+++ b/rita/src/rita_common/dashboard/mod.rs
@@ -37,7 +37,10 @@ impl Default for Dashboard {
 enum OwnInfoError {
     #[fail(display = "Unable to round balance of {} down to 1 ETH", _0)]
     RoundDownError(Int256),
-    #[fail(display = "Unable to downcast value {} to signed 64 bits", _0)]
+    #[fail(
+        display = "Unable to downcast value {} to signed 64 bits",
+        _0
+    )]
     DownCastError(Int256),
 }
 

--- a/rita/src/rita_common/network_endpoints/mod.rs
+++ b/rita/src/rita_common/network_endpoints/mod.rs
@@ -47,8 +47,7 @@ pub fn make_payments(
     PaymentController::from_registry()
         .send(rita_common::payment_controller::PaymentReceived(
             pmt.0.clone(),
-        ))
-        .from_err()
+        )).from_err()
         .and_then(|_| Ok(HttpResponse::Ok().into()))
         .responder()
 }
@@ -89,8 +88,7 @@ pub fn hello_response(
                 wg_port: tunnel.0.listen_port,
                 have_tunnel: Some(tunnel.1),
             }))
-        })
-        .from_err()
+        }).from_err()
         .responder()
 }
 

--- a/rita/src/rita_common/peer_listener/message.rs
+++ b/rita/src/rita_common/peer_listener/message.rs
@@ -153,9 +153,7 @@ fn test_encode_im_here() {
     let data = PeerMessage::ImHere(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff)).encode();
     assert_eq!(
         data,
-        vec![
-            91, 0, 19, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 192, 10, 2, 255,
-        ]
+        vec![91, 0, 19, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 192, 10, 2, 255,]
     );
 }
 

--- a/rita/src/rita_common/rita_loop/mod.rs
+++ b/rita/src/rita_common/rita_loop/mod.rs
@@ -159,8 +159,7 @@ impl Handler<Tick> for RitaLoop {
             TunnelManager::from_registry()
                 .send(TriggerGC(Duration::from_secs(
                     SETTING.get_network().tunnel_timeout_seconds,
-                )))
-                .then(move |res| {
+                ))).then(move |res| {
                     info!(
                         "TunnelManager GC pass completed in {}s {}ms, with result {:?}",
                         start.elapsed().as_secs(),
@@ -168,8 +167,7 @@ impl Handler<Tick> for RitaLoop {
                         res
                     );
                     res
-                })
-                .then(|_| Ok(())),
+                }).then(|_| Ok(())),
         );
 
         let start = Instant::now();
@@ -185,8 +183,7 @@ impl Handler<Tick> for RitaLoop {
                         res
                     );
                     res
-                })
-                .then(|_| Ok(())),
+                }).then(|_| Ok(())),
         );
 
         let start = Instant::now();

--- a/rita/src/rita_common/tunnel_manager/mod.rs
+++ b/rita/src/rita_common/tunnel_manager/mod.rs
@@ -663,7 +663,7 @@ impl TunnelManager {
                 return_bool = true;
             }
         }
-        trace!(
+        info!(
             "no tunnel found for {:?}%{:?} creating",
             peer.contact_socket.ip(),
             peer.ifidx,
@@ -740,7 +740,7 @@ impl Handler<TunnelStateChange> for TunnelManager {
                                     tunnel.state = TunnelState::Registered;
                                 }
                                 TunnelState::Registered => {
-                                    warn!("Tunnel {:?} already in registered state", tunnel);
+                                    trace!("Tunnel {:?} already in registered state", tunnel);
                                     continue;
                                 }
                             }
@@ -753,7 +753,7 @@ impl Handler<TunnelStateChange> for TunnelManager {
                                     tunnel.state = TunnelState::NotRegistered;
                                 }
                                 TunnelState::NotRegistered => {
-                                    info!("Tunnel {:?} already in not registered state.", tunnel);
+                                    trace!("Tunnel {:?} already in not registered state.", tunnel);
                                     continue;
                                 }
                             }

--- a/rita/src/rita_exit/db_client/mod.rs
+++ b/rita/src/rita_exit/db_client/mod.rs
@@ -258,6 +258,8 @@ fn send_mail(client: &models::Client) -> Result<(), Error> {
         return Ok(());
     };
 
+    info!("Sending exit signup email for client");
+
     let reg = Handlebars::new();
 
     let email = EmailBuilder::new()

--- a/rita/src/rita_exit/db_client/mod.rs
+++ b/rita/src/rita_exit/db_client/mod.rs
@@ -284,8 +284,7 @@ fn send_mail(client: &models::Client) -> Result<(), Error> {
             .credentials(Credentials::new(
                 SETTING.get_mailer().unwrap().smtp_username,
                 SETTING.get_mailer().unwrap().smtp_password,
-            ))
-            .smtp_utf8(true)
+            )).smtp_utf8(true)
             .authentication_mechanism(Mechanism::Plain)
             .connection_reuse(ConnectionReuseParameters::ReuseUnlimited)
             .build();

--- a/rita/src/rita_exit/rita_loop/mod.rs
+++ b/rita/src/rita_exit/rita_loop/mod.rs
@@ -71,7 +71,7 @@ impl Handler<Tick> for RitaLoop {
             DbClient::from_registry()
                 .send(ListClients {})
                 .into_actor(self)
-                .then(|res, _act, _ctx| {
+                .then(move |res, _act, _ctx| {
                     let clients = res.unwrap().unwrap();
                     let ids = clients
                         .clone()
@@ -105,16 +105,15 @@ impl Handler<Tick> for RitaLoop {
                         Ok(_) => (),
                         Err(e) => warn!("Error in Exit WG setup {:?}", e),
                     }
-
+                    info!(
+                        "Rita Exit loop completed in {}s {}ms",
+                        start.elapsed().as_secs(),
+                        start.elapsed().subsec_nanos() / 1000000
+                    );
                     actix::fut::ok(())
                 }),
         );
 
-        info!(
-            "Rita Exit loop completed in {}s {}ms",
-            start.elapsed().as_secs(),
-            start.elapsed().subsec_nanos() / 1000000
-        );
         Ok(())
     }
 }

--- a/rita/src/rita_exit/traffic_watcher/mod.rs
+++ b/rita/src/rita_exit/traffic_watcher/mod.rs
@@ -109,7 +109,19 @@ pub fn watch<T: Read + Write>(mut babel: Babel<T>, clients: Vec<Identity>) -> Re
     let output_counters = KI.read_exit_server_counters(&ExitFilterTarget::Output)?;
 
     trace!("input exit counters: {:?}", input_counters);
+    let mut total_in: u64 = 0;
+    for entry in input_counters.iter() {
+        let input = entry.1;
+        total_in += input;
+    }
+    info!("Total input of {} bytes this round", total_in);
     trace!("output exit counters: {:?}", output_counters);
+    let mut total_out: u64 = 0;
+    for entry in output_counters.iter() {
+        let output = entry.1;
+        total_out += output;
+    }
+    info!("Total output of {} bytes this round", total_in);
 
     let mut debts = HashMap::new();
 
@@ -141,6 +153,14 @@ pub fn watch<T: Read + Write>(mut babel: Babel<T>, clients: Vec<Identity>) -> Re
     }
 
     trace!("Collated total exit debts: {:?}", debts);
+
+    info!("Computed exit debts for {:?} clients", debts.len());
+    let mut total_income = Int256::zero();
+    for entry in debts.iter() {
+        let income = entry.1;
+        total_income += income;
+    }
+    info!("Total income of {:?} Wei this round", total_income);
 
     for (from, amount) in debts {
         let update = debt_keeper::TrafficUpdate {

--- a/stats_server/src/main.rs
+++ b/stats_server/src/main.rs
@@ -52,8 +52,7 @@ fn index(
             resp.body()
                 .from_err()
                 .and_then(|body| Ok(HttpResponse::Ok().body(body)))
-        })
-        .responder()
+        }).responder()
 }
 
 fn main() {
@@ -72,10 +71,10 @@ fn main() {
         App::with_state(ProxyState {
             insert_url: insert_url.clone(),
         }).middleware(middleware::Logger::default())
-            .resource("/stats/", |r| r.method(http::Method::POST).with(index))
+        .resource("/stats/", |r| r.method(http::Method::POST).with(index))
     }).bind(args.flag_bind_url)
-        .unwrap()
-        .start();
+    .unwrap()
+    .start();
 
     let _ = sys.run();
 }


### PR DESCRIPTION
This adds some more info messages with better system summary data
such as total bytes in and out in a billing cycle.

It also demotes some warnings to trace messages as they dominated
total warnings counts without being all that important.