### PR TITLE
Fix exit switching parsing

### DIFF
--- a/althea_kernel_interface/src/exit_client_tunnel.rs
+++ b/althea_kernel_interface/src/exit_client_tunnel.rs
@@ -2,7 +2,7 @@ use super::{KernelInterface, KernelInterfaceError};
 
 use failure::Error;
 
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 impl KernelInterface {
     pub fn set_client_exit_tunnel_config(
@@ -58,7 +58,7 @@ impl KernelInterface {
             ],
         )?;
 
-        let prev_ip = self.get_global_device_ip("wg_exit");
+        let prev_ip: Result<Ipv4Addr, Error> = self.get_global_device_ip_v4("wg_exit");
 
         match prev_ip {
             Ok(prev_ip) => {


### PR DESCRIPTION
So during my TunnelManager refactor I made the ip parsing in a few
functions more restrictive. During this process I switched a function
used to detect the old exit ip on the exit tunnel from searching for ipaddr
in general to ipv6 addresses, meaning it would never identify ipv4 addresses
and fail to cleanup any leftovers from a previous tunnel.

This not only solves that problem but also goes a step further to prevent
the tunnel from being re-created every loop, reducing commands and possible
error.