### PR TITLE
Add remote logging functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,6 +1863,7 @@ dependencies = [
  "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "settings 0.1.0",
+ "syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2193,6 +2194,17 @@ dependencies = [
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syslog"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3000,6 +3012,7 @@ dependencies = [
 "checksum syn 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9056ebe7f2d6a38bc63171816fd1d3430da5a43896de21676dc5c0a4b8274a11"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb9b7550d063ea184027c9b8c20ac167cd36d3e06b3a40bceb9d746dc1a7b7"
+"checksum syslog 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a0641142b4081d3d44beffa4eefd7346a228cdf91ed70186db2ca2cef762d327"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "55c1195ef8513f3273d55ff59fe5da6940287a0d7a98331254397f464833675b"
 "checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"

--- a/docs/api/router-dashboard.md
+++ b/docs/api/router-dashboard.md
@@ -703,6 +703,7 @@ the router will send logs to the configured exit over syslog port 514
 
 Sets the level of remote logging
 
+<<<<<<< HEAD
 0: Error
 1: Debug
 2: Info
@@ -711,6 +712,16 @@ Sets the level of remote logging
 
 Do not use anything above one by default ever!
 it will actually charge
+=======
+ERROR
+WARN
+INFO
+DEBUG
+TRACE
+
+Do not use anything above WARN by default ever!
+it will actually consume nontrival bandwidth
+>>>>>>> Use loglevels in the settings
 
 - URL: `<rita ip>:<rita_dashboard_port>/logging/level/{u8}'
 - Method: `POST`

--- a/docs/api/router-dashboard.md
+++ b/docs/api/router-dashboard.md
@@ -25,6 +25,8 @@ This file documents the dashboard API found in Rita client.
 
 `curl 127.0.0.1:4877/info`
 
+---
+
 ## /neighbors
 
 - URL: `<rita ip>:<rita_dashboard_port>/neighbors`
@@ -61,6 +63,8 @@ This file documents the dashboard API found in Rita client.
 - Sample Call:
 
 `curl 127.0.0.1:4877/neighbors`
+
+---
 
 ## /exits
 
@@ -101,6 +105,8 @@ This file documents the dashboard API found in Rita client.
 
 `curl 127.0.0.1:4877/exits`
 
+---
+
 ## /exits/{nickname}/reset
 
 - URL: `<rita ip>:<rita_dashboard_port>/exits/{nickname}/reset'
@@ -123,6 +129,8 @@ This file documents the dashboard API found in Rita client.
 - Sample Call:
 
 `curl -XPOST 127.0.0.1:4877/exits/borked/reset`
+
+---
 
 ## /exits/{nickname}/select
 
@@ -147,6 +155,8 @@ This file documents the dashboard API found in Rita client.
 
 `curl -XPOST 127.0.0.1:4877/exits/borked/reset`
 
+---
+
 ## /exits/{nickname}/register
 
 - URL: `<rita ip>:<rita_dashboard_port>/exits/{nickname}/register'
@@ -170,6 +180,8 @@ This file documents the dashboard API found in Rita client.
 - Sample Call:
 
 `curl -XPOST 127.0.0.1:4877/exits/borked/register`
+
+---
 
 ## /exits/{nickname}/verify/{code}
 
@@ -197,6 +209,8 @@ This file documents the dashboard API found in Rita client.
 - Sample Call:
 
 `curl -XPOST 127.0.0.1:4877/exits/borked/register`
+
+---
 
 ## /settings
 
@@ -346,6 +360,7 @@ This file documents the dashboard API found in Rita client.
 ---
 
 ## /wifi_settings
+
 - URL: `<rita ip>:<rita_dashboard_port>/wifi_settings`
 - Method: `POST`
 - URL Params: `Content-Type: application/json`
@@ -353,15 +368,16 @@ This file documents the dashboard API found in Rita client.
 - Success Response:
   - Code: 200 OK
   - Contents:
+
 ```
 {}
 ```
+
 - Error Response: `500 Server Error`
 - Sample Call:
-`curl -XPOST 127.0.0.1:<rita_dashboard_port>/settings -H 'Content-Type: application/json' -i -d '{"default_radio0": {"ssid": "NetworkName"}}'`
+  `curl -XPOST 127.0.0.1:<rita_dashboard_port>/settings -H 'Content-Type: application/json' -i -d '{"default_radio0": {"ssid": "NetworkName"}}'`
 
 ---
-
 
 ## /wifi_settings/ssid
 
@@ -459,7 +475,7 @@ Calling HTTP `DELETE` request on this endpoint causes all tables to be wiped out
 
 `curl -XDELETE 127.0.0.1:<rita_dashboard_port>/database`
 
---
+---
 
 ## /debts
 
@@ -634,15 +650,18 @@ Format:
 ---
 
 ## /mesh_ip POST
+
 - URL: `<rita ip>:<rita_dashboard_port>/mesh_ip`
 - Method: `POST`
 - URL Params: `None`
 - Contents:
+
 ```json
 {
-"mesh_ip": "<new_ipv6_mesh_ip>"
+  "mesh_ip": "<new_ipv6_mesh_ip>"
 }
 ```
+
 - Success Response:
   - This endpoint requires Rita to restart and therefore should give an empty
     response
@@ -653,3 +672,62 @@ Format:
 
 ---
 
+## /remote_logging/enabled/{bool}
+
+Enables or disables remote logging, if enabled on next boot
+the router will send logs to the configured exit over syslog port 514
+
+- URL: `<rita ip>:<rita_dashboard_port>/logging/enabled/{bool}'
+- Method: `POST`
+- URL Params: 'enabled'
+- Data Params: `None`
+- Success Response:
+  - Code: 200 OK
+  - Contents: `{}`
+- Error Response: `400 Bad Request`
+- Error Contents:
+
+```json
+{
+  "error": "<description>"
+}
+```
+
+- Sample Call:
+
+`curl -XPOST 127.0.0.1:4877/remote_logging/enabled/true`
+
+---
+
+## /remote_logging/level/{u8}
+
+Sets the level of remote logging
+
+0: Error
+1: Debug
+2: Info
+3: Trace
+\_: Error
+
+Do not use anything above one by default ever!
+it will actually charge
+
+- URL: `<rita ip>:<rita_dashboard_port>/logging/level/{u8}'
+- Method: `POST`
+- URL Params: level
+- Data Params: `None`
+- Success Response:
+  - Code: 200 OK
+  - Contents: `{}`
+- Error Response: `400 Bad Request`
+- Error Contents:
+
+```json
+{
+  "error": "<description>"
+}
+```
+
+- Sample Call:
+
+`curl -XPOST 127.0.0.1:4877/remote_logging/level/3`

--- a/docs/api/router-dashboard.md
+++ b/docs/api/router-dashboard.md
@@ -677,12 +677,16 @@ Format:
 Enables or disables remote logging, if enabled on next boot
 the router will send logs to the configured exit over syslog port 514
 
+This endpoint will restart the router so no response
+is expected, an error response indicates that there's
+somthing wrong with the input data.
+
 - URL: `<rita ip>:<rita_dashboard_port>/logging/enabled/{bool}'
 - Method: `POST`
 - URL Params: 'enabled'
 - Data Params: `None`
 - Success Response:
-  - Code: 200 OK
+  - Code: None
   - Contents: `{}`
 - Error Response: `400 Bad Request`
 - Error Contents:
@@ -723,12 +727,16 @@ Do not use anything above WARN by default ever!
 it will actually consume nontrival bandwidth
 >>>>>>> Use loglevels in the settings
 
+This endpoint will restart the router so no response
+is expected, an error response indicates that there's
+somthing wrong with the input data.
+
 - URL: `<rita ip>:<rita_dashboard_port>/logging/level/{u8}'
 - Method: `POST`
 - URL Params: level
 - Data Params: `None`
 - Success Response:
-  - Code: 200 OK
+  - Code: None
   - Contents: `{}`
 - Error Response: `400 Bad Request`
 - Error Contents:

--- a/rita/Cargo.toml
+++ b/rita/Cargo.toml
@@ -27,6 +27,7 @@ exit_db = { path = "../exit_db" }
 num256 = { path = "../num256" }
 settings = { path = "../settings" }
 
+syslog = "^4.0"
 actix = "0.7.4"
 actix-web = { version = "0.7.4", default_features = false }
 actix_derive = "0.3.0"

--- a/rita/src/client.rs
+++ b/rita/src/client.rs
@@ -7,7 +7,10 @@
 //! This file initilizes the dashboard endpoints for the client as well as the common and client
 //! specific actors.
 
-#![cfg_attr(feature = "system_alloc", feature(alloc_system, allocator_api))]
+#![cfg_attr(
+    feature = "system_alloc",
+    feature(alloc_system, allocator_api)
+)]
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 
@@ -212,10 +215,10 @@ fn main() {
             r.method(Method::POST).with(make_payments)
         })
     }).workers(1)
-        .bind(format!("[::0]:{}", SETTING.get_network().rita_contact_port))
-        .unwrap()
-        .shutdown_timeout(0)
-        .start();
+    .bind(format!("[::0]:{}", SETTING.get_network().rita_contact_port))
+    .unwrap()
+    .shutdown_timeout(0)
+    .start();
 
     // dashboard
     server::new(|| {
@@ -227,8 +230,7 @@ fn main() {
                 "/dao_list/remove/{address}",
                 Method::POST,
                 remove_from_dao_list,
-            )
-            .route("/debts", Method::GET, get_debts)
+            ).route("/debts", Method::GET, get_debts)
             .route("/exits", Method::GET, get_exit_info)
             .route("/exits/{name}/register", Method::POST, register_to_exit)
             .route("/exits/{name}/reset", Method::POST, reset_exit)
@@ -237,18 +239,15 @@ fn main() {
                 "/exits/{name}/verify/{code}",
                 Method::POST,
                 verify_on_exit_with_code,
-            )
-            .route(
+            ).route(
                 "/remote_logging/enabled/{enabled}",
                 Method::POST,
                 remote_logging,
-            )
-            .route(
+            ).route(
                 "/remote_logging/level/{level}",
                 Method::POST,
                 remote_logging_level,
-            )
-            .route("/info", Method::GET, get_own_info)
+            ).route("/info", Method::GET, get_own_info)
             .route("/interfaces", Method::GET, get_interfaces)
             .route("/interfaces", Method::POST, set_interfaces)
             .route("/mesh_ip", Method::GET, get_mesh_ip)
@@ -262,13 +261,12 @@ fn main() {
             .route("/wifi_settings", Method::GET, get_wifi_config)
             .route("/wipe", Method::POST, wipe)
     }).workers(1)
-        .bind(format!(
-            "[::0]:{}",
-            SETTING.get_network().rita_dashboard_port
-        ))
-        .unwrap()
-        .shutdown_timeout(0)
-        .start();
+    .bind(format!(
+        "[::0]:{}",
+        SETTING.get_network().rita_dashboard_port
+    )).unwrap()
+    .shutdown_timeout(0)
+    .start();
 
     let common = rita_common::rita_loop::RitaLoop::new();
     let _: Addr<_> = common.start();

--- a/rita/src/rita_client/dashboard/network_endpoints.rs
+++ b/rita/src/rita_client/dashboard/network_endpoints.rs
@@ -332,3 +332,20 @@ pub fn get_wifi_config(
         .and_then(move |reply| Ok(Json(reply?)))
         .responder()
 }
+
+pub fn remote_logging(path: Path<bool>) -> Box<Future<Item = HttpResponse, Error = Error>> {
+    let enabled = path.into_inner();
+    debug!("/loging/enable/{} hit", enabled);
+
+    SETTING.get_log_mut().enabled = enabled;
+
+    return Box::new(future::ok(HttpResponse::Ok().json(())));
+}
+
+pub fn remote_logging_level(path: Path<u8>) -> Box<Future<Item = HttpResponse, Error = Error>> {
+    let level = path.into_inner();
+    debug!("/loging/level/{}", level);
+
+    SETTING.get_log_mut().level = level;
+    return Box::new(future::ok(HttpResponse::Ok().json(())));
+}

--- a/rita/src/rita_client/dashboard/network_endpoints.rs
+++ b/rita/src/rita_client/dashboard/network_endpoints.rs
@@ -340,6 +340,10 @@ pub fn remote_logging(path: Path<bool>) -> Box<Future<Item = HttpResponse, Error
 
     SETTING.get_log_mut().enabled = enabled;
 
+    if let Err(e) = KI.run_command("/etc/init.d/rita", &["restart"]) {
+        return Box::new(future::err(e));
+    }
+
     return Box::new(future::ok(HttpResponse::Ok().json(())));
 }
 
@@ -359,6 +363,10 @@ pub fn remote_logging_level(path: Path<String>) -> Box<Future<Item = HttpRespons
     };
 
     SETTING.get_log_mut().level = log_level.to_string();
+
+    if let Err(e) = KI.run_command("/etc/init.d/rita", &["restart"]) {
+        return Box::new(future::err(e));
+    }
 
     return Box::new(future::ok(HttpResponse::Ok().json(())));
 }

--- a/rita/src/rita_client/exit_manager/mod.rs
+++ b/rita/src/rita_client/exit_manager/mod.rs
@@ -55,8 +55,8 @@ fn enable_remote_logging(server_internal_ip: IpAddr) -> Result<(), LogError> {
         Err(_) => LevelFilter::Error,
     };
     let res = init_udp(
-        "0.0.0.0:5454",
-        &format!("{}:514", server_internal_ip),
+        &format!("0.0.0.0:{}", log.send_port),
+        &format!("{}:{}", server_internal_ip, log.dest_port),
         SETTING.get_network().wg_public_key.clone(),
         Facility::LOG_USER,
         level,

--- a/rita/src/rita_client/exit_manager/mod.rs
+++ b/rita/src/rita_client/exit_manager/mod.rs
@@ -50,12 +50,9 @@ fn enable_remote_logging(server_internal_ip: IpAddr) -> Result<(), LogError> {
     // now that the exit tunnel is up we can start logging over it
     let log = SETTING.get_log();
     trace!("About to enable remote logging");
-    let level = match log.level {
-        0 => LevelFilter::Error,
-        1 => LevelFilter::Warn,
-        2 => LevelFilter::Info,
-        3 => LevelFilter::Trace,
-        _ => LevelFilter::Error,
+    let level: LevelFilter = match log.level.parse() {
+        Ok(level) => level,
+        Err(_) => LevelFilter::Error,
     };
     let res = init_udp(
         "0.0.0.0:5454",

--- a/settings/src/lib.rs
+++ b/settings/src/lib.rs
@@ -26,6 +26,7 @@ extern crate serde_derive;
 extern crate log;
 
 #[cfg(test)]
+use log::LevelFilter;
 use std::sync::Mutex;
 
 extern crate serde;
@@ -176,8 +177,8 @@ fn default_logging() -> bool {
     false
 }
 
-fn default_logging_level() -> u8 {
-    0
+fn default_logging_level() -> String {
+    "ERROR".to_string()
 }
 
 /// Remote logging settings. Used to control remote logs being
@@ -190,14 +191,14 @@ pub struct LoggingSettings {
     #[serde(default = "default_logging")]
     pub enabled: bool,
     #[serde(default = "default_logging_level")]
-    pub level: u8,
+    pub level: String,
 }
 
 impl Default for LoggingSettings {
     fn default() -> Self {
         LoggingSettings {
             enabled: false,
-            level: 0, // 0 = error, 1 = warn, 2 = info, 3 = trace
+            level: "ERROR".to_string(),
         }
     }
 }

--- a/settings/src/lib.rs
+++ b/settings/src/lib.rs
@@ -181,6 +181,14 @@ fn default_logging_level() -> String {
     "ERROR".to_string()
 }
 
+fn default_logging_send_port() -> u16 {
+    5044
+}
+
+fn default_logging_dest_port() -> u16 {
+    514
+}
+
 /// Remote logging settings. Used to control remote logs being
 /// forwarded to an aggregator on the exit. The reason there is
 /// no general destination setting is that syslog udp is not
@@ -192,6 +200,10 @@ pub struct LoggingSettings {
     pub enabled: bool,
     #[serde(default = "default_logging_level")]
     pub level: String,
+    #[serde(default = "default_logging_send_port")]
+    pub send_port: u16,
+    #[serde(default = "default_logging_dest_port")]
+    pub dest_port: u16,
 }
 
 impl Default for LoggingSettings {
@@ -199,6 +211,8 @@ impl Default for LoggingSettings {
         LoggingSettings {
             enabled: false,
             level: "ERROR".to_string(),
+            send_port: 5044,
+            dest_port: 514,
         }
     }
 }


### PR DESCRIPTION
This adds syslog for remote syslog logging. The primary issue here is that
syslog is unencrypted, so we can't just forward it to a random internet
address, instead we send it to the exit and then configure exits to forward
this data off to the logging aggregation server. This has the nice secondary
effect of making logging more efficient on the aggregation server and securing
the logs since they transit over wg_exit only and they are tls encrypted from
the exit to the aggregation. it wlll of course eventually be a problem when there are non
Althea exits around. We can upgrade the syslog crate with TLS by then hopefully. 

Also added are dashboard endpoints
/remote_logging/enabled/{bool}
/remote_logging/level/{0-3}

Sadly a reboot is required to enable log aggregation after using these endpoints
since logging backends can only be initialized once in Rust. Likewise once you
enable remote logging logs no longer appear locally at any point.

These catch-22's are the best solution to the very hard problem of sheer log volume
we can't have an external on router program process the logs because at the trace
level we will overhwelm internal storage in about a minute and memory in less than 10.

By using rust syslog we can send logs directly over udp at the cost of having to restart
the router and not being able to see the logs locally.