### PR TITLE
Set LAN interface even if none exist

### DIFF
--- a/rita/src/rita_client/dashboard/interfaces.rs
+++ b/rita/src/rita_client/dashboard/interfaces.rs
@@ -268,8 +268,14 @@ pub fn ethernet_transform_mode(
                     return_codes.push(ret);
                 }
                 Err(e) => {
-                    warn!("Trying to read lan ifname returned {:?}", e);
-                    return_codes.push(Err(e));
+                    if e.to_string().contains("Entry not found") {
+                        trace!("No LAN interfaces found, setting one now");
+                        let ret = KI.set_uci_var("network.lan.ifname", &ifname);
+                        return_codes.push(ret);
+                    } else {
+                        warn!("Trying to read lan ifname returned {:?}", e);
+                        return_codes.push(Err(e));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes an issue where if you had removed all LAN interfaces you wouldn't be
able to re-add one since the network.lan.ifname setting wouldn't exist and the
code would return an Err in that case.

Now if the setting doesn't exist, we go ahead and set it instead of returning 
an Err.