### PR TITLE
Limit to one LAN ethernet interface

### DIFF
--- a/rita/src/rita_client/dashboard/interfaces.rs
+++ b/rita/src/rita_client/dashboard/interfaces.rs
@@ -175,6 +175,14 @@ impl Handler<InterfaceToSet> for Dashboard {
                     bail!("There can only be one WAN interface!");
                 }
             }
+        } else if target_mode == InterfaceMode::LAN && !iface_name.contains("wlan") {
+            // we can only have one LAN ethernet interface, check for others
+            for entry in interfaces {
+                let mode = entry.1;
+                if mode == InterfaceMode::LAN {
+                    bail!("There can only be one LAN ethernet interface!");
+                }
+            }
         }
 
         // in theory you can have all sorts of wonky interface names, but we know


### PR DESCRIPTION
Prevent users from setting more than one LAN ethernet interface for now until we figure out how to get that scenario working properly