### PR TITLE
Report device name

### DIFF
--- a/clu/src/lib.rs
+++ b/clu/src/lib.rs
@@ -151,7 +151,12 @@ fn linux_init(config: Arc<RwLock<settings::RitaSettingsStruct>>) -> Result<(), E
                 if line.starts_with("device:") {
                     let mut array = line.split(" ");
                     array.next();
-                    network_settings.device = array.next().map(|s| s.to_string());
+                    let device = array.next();
+
+                    if device.is_some() {
+                        network_settings.device = Some(device.unwrap().to_string());
+                    }
+
                     break;
                 }
             }

--- a/clu/src/lib.rs
+++ b/clu/src/lib.rs
@@ -138,12 +138,13 @@ fn linux_init(config: Arc<RwLock<settings::RitaSettingsStruct>>) -> Result<(), E
            info!("Device name is {}", existing_device); 
         } 
         None => {
-            info!("No device name was found, reading from /etc/althea-firmware-release");
+            let release_file_path = "/etc/althea-firmware-release";
+            info!("No device name was found, reading from {}", release_file_path);
 
             let mut contents = String::new();
-            match File::open("/etc/althea-firmware-release") {
+            match File::open(release_file_path) {
                 Ok(mut f) => { f.read_to_string(&mut contents)?; },
-                Err(e) => warn!("Couldn't open /etc/althea-firmware-release: {}", e),
+                Err(e) => warn!("Couldn't open {}: {}", release_file_path, e),
             };
 
             for line in contents.lines() {
@@ -156,7 +157,7 @@ fn linux_init(config: Arc<RwLock<settings::RitaSettingsStruct>>) -> Result<(), E
             }
 
             if network_settings.device.is_none() {
-                warn!("Device name could not be read from /etc/althea-firmware-release");
+                warn!("Device name could not be read from {}", release_file_path);
             } 
         },
     }

--- a/clu/src/lib.rs
+++ b/clu/src/lib.rs
@@ -154,13 +154,12 @@ fn linux_init(config: Arc<RwLock<settings::RitaSettingsStruct>>) -> Result<(), E
 
             for line in contents.lines() {
                 if line.starts_with("device:") {
-                    let mut array = line.split(" ");
-                    array.next();
-                    let device = array.next();
+                    let device = line.split(" ").nth(1).ok_or(format_err!(
+                        "Could not obtain device name from line {:?}",
+                        line
+                    ))?;
 
-                    if device.is_some() {
-                        network_settings.device = Some(device.unwrap().to_string());
-                    }
+                    network_settings.device = Some(device.to_string());
 
                     break;
                 }

--- a/clu/src/lib.rs
+++ b/clu/src/lib.rs
@@ -25,10 +25,10 @@ use althea_kernel_interface::KI;
 extern crate althea_kernel_interface;
 use rand::distributions::Alphanumeric;
 use regex::Regex;
-use std::path::Path;
-use std::sync::{Arc, RwLock};
 use std::fs::File;
 use std::io::Read;
+use std::path::Path;
+use std::sync::{Arc, RwLock};
 
 extern crate althea_types;
 extern crate regex;
@@ -135,15 +135,20 @@ fn linux_init(config: Arc<RwLock<settings::RitaSettingsStruct>>) -> Result<(), E
 
     match device_option {
         Some(existing_device) => {
-           info!("Device name is {}", existing_device); 
-        } 
+            info!("Device name is {}", existing_device);
+        }
         None => {
             let release_file_path = "/etc/althea-firmware-release";
-            info!("No device name was found, reading from {}", release_file_path);
+            info!(
+                "No device name was found, reading from {}",
+                release_file_path
+            );
 
             let mut contents = String::new();
             match File::open(release_file_path) {
-                Ok(mut f) => { f.read_to_string(&mut contents)?; },
+                Ok(mut f) => {
+                    f.read_to_string(&mut contents)?;
+                }
                 Err(e) => warn!("Couldn't open {}: {}", release_file_path, e),
             };
 
@@ -163,8 +168,8 @@ fn linux_init(config: Arc<RwLock<settings::RitaSettingsStruct>>) -> Result<(), E
 
             if network_settings.device.is_none() {
                 warn!("Device name could not be read from {}", release_file_path);
-            } 
-        },
+            }
+        }
     }
 
     // Setting the compat value to None prevents serde from putting it back in the config (thanks

--- a/docs/api/router-dashboard.md
+++ b/docs/api/router-dashboard.md
@@ -14,7 +14,8 @@ This file documents the dashboard API found in Rita client.
 
 ```
 {
-    "balance":-1029470595
+    "balance": -1029470595,
+    "device": "mynet-n750",
     "version": "v0.1.1"
 }
 ```

--- a/rita/src/rita_common/dashboard/mod.rs
+++ b/rita/src/rita_common/dashboard/mod.rs
@@ -10,8 +10,8 @@ use futures::Future;
 use rita_common::payment_controller::{GetOwnBalance, PaymentController};
 
 use num256::Int256;
-use SETTING;
 use settings::RitaCommonSettings;
+use SETTING;
 
 pub mod network_endpoints;
 use num_traits::ops::checked::CheckedDiv;
@@ -72,7 +72,7 @@ impl Handler<GetOwnInfo> for Dashboard {
                         let balance = balance
                             .checked_div(&Int256::from(1_000_000_000i64))
                             .ok_or(OwnInfoError::RoundDownError(balance.clone()))?;
- 
+
                         Ok(OwnInfo {
                             balance: balance
                                 .to_i64()

--- a/rita/src/rita_common/dashboard/mod.rs
+++ b/rita/src/rita_common/dashboard/mod.rs
@@ -49,7 +49,7 @@ enum OwnInfoError {
 #[derive(Serialize)]
 pub struct OwnInfo {
     pub balance: i64,
-    pub device: String,
+    pub device: Option<String>,
     pub version: String,
 }
 
@@ -73,16 +73,11 @@ impl Handler<GetOwnInfo> for Dashboard {
                             .checked_div(&Int256::from(1_000_000_000i64))
                             .ok_or(OwnInfoError::RoundDownError(balance.clone()))?;
  
-                        let device = match SETTING.get_network().device.clone() {
-                            Some(device) => { device.to_string() },
-                            None => { "".to_string() }
-                        };
-
                         Ok(OwnInfo {
                             balance: balance
                                 .to_i64()
                                 .ok_or(OwnInfoError::DownCastError(balance))?,
-                            device: device,
+                            device: SETTING.get_network().device.clone(),
                             version: env!("CARGO_PKG_VERSION").to_string(),
                         })
                     }

--- a/rita/src/rita_common/dashboard/mod.rs
+++ b/rita/src/rita_common/dashboard/mod.rs
@@ -10,6 +10,8 @@ use futures::Future;
 use rita_common::payment_controller::{GetOwnBalance, PaymentController};
 
 use num256::Int256;
+use SETTING;
+use settings::RitaCommonSettings;
 
 pub mod network_endpoints;
 use num_traits::ops::checked::CheckedDiv;
@@ -47,6 +49,7 @@ enum OwnInfoError {
 #[derive(Serialize)]
 pub struct OwnInfo {
     pub balance: i64,
+    pub device: String,
     pub version: String,
 }
 
@@ -69,10 +72,17 @@ impl Handler<GetOwnInfo> for Dashboard {
                         let balance = balance
                             .checked_div(&Int256::from(1_000_000_000i64))
                             .ok_or(OwnInfoError::RoundDownError(balance.clone()))?;
+ 
+                        let device = match SETTING.get_network().device.clone() {
+                            Some(device) => { device.to_string() },
+                            None => { "".to_string() }
+                        };
+
                         Ok(OwnInfo {
                             balance: balance
                                 .to_i64()
                                 .ok_or(OwnInfoError::DownCastError(balance))?,
+                            device: device,
                             version: env!("CARGO_PKG_VERSION").to_string(),
                         })
                     }

--- a/settings/src/lib.rs
+++ b/settings/src/lib.rs
@@ -144,6 +144,9 @@ pub struct NetworkSettings {
     /// How long do we wait without contact from a peer before we delete the associated tunnel?
     #[serde(default = "default_tunnel_timeout")]
     pub tunnel_timeout_seconds: u64,
+    /// The name of the device or router model
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device: Option<String>,
 }
 
 impl Default for NetworkSettings {
@@ -169,6 +172,7 @@ impl Default for NetworkSettings {
             default_route: Vec::new(),
             is_gateway: false,
             tunnel_timeout_seconds: default_tunnel_timeout(),
+            device: None,
         }
     }
 }


### PR DESCRIPTION
Adds an optional string device field to the network settings in the config file if it doesn't already exist by reading the device name from /etc/althea-firmware-release

Report the device name in the common dashboard /info endpoint 