### PR TITLE
Add support for meshpoint in interfaces

### DIFF
--- a/docs/api/router-dashboard.md
+++ b/docs/api/router-dashboard.md
@@ -607,7 +607,7 @@ Calling HTTP `GET` request on this endpoint provides a list of availabile ports 
 - Error Response: `500 Server Error`
 - Sample Call
 
-`curl 127.0..1:<rita_dashboard_port>/interfaces'
+`curl 127.0.0.1:<rita_dashboard_port>/interfaces'
 
 Format:
 
@@ -639,7 +639,7 @@ the `GET` version of this same endpoint.
 - Error Response: `500 Server Error`
 - Sample Call
 
-`curl 127.0..1:<rita_dashboard_port>/interfaces -H 'Content-Type: application/json' -i -d '{"interface":"wlan0", "mode":"LAN"}'`
+`curl 127.0.0.1:<rita_dashboard_port>/interfaces -H 'Content-Type: application/json' -i -d '{"interface":"wlan0", "mode":"LAN"}'`
 
 Format:
 
@@ -725,7 +725,8 @@ TRACE
 
 Do not use anything above WARN by default ever!
 it will actually consume nontrival bandwidth
->>>>>>> Use loglevels in the settings
+
+> > > > > > > Use loglevels in the settings
 
 This endpoint will restart the router so no response
 is expected, an error response indicates that there's


### PR DESCRIPTION
This removes support for the legacy adhoc mode on wireless interfaces
and replaces it with dual purpose 'meshpoint' the reason it needs a
seperate mode from 'mesh' is that meshpoint is not exclusive the LAN
wifi will continue to operate while meshpoint is enabled.

This pull adds handling for 'Meshpoint' as well as removes support
for adhoc mode. Adhoc mode requires setting a significant number of
vars at runtime, while meshpoint can be configured entierly at firmware
build time and simply toggled with a much lower chance of failure.