### PR TITLE
Fix exit tunnel setup cases

### DIFF
--- a/althea_kernel_interface/src/ip_route.rs
+++ b/althea_kernel_interface/src/ip_route.rs
@@ -21,7 +21,7 @@ impl ToString for IpRoute {
 }
 
 impl KernelInterface {
-    fn get_default_route(&self) -> Option<Vec<String>> {
+    pub fn get_default_route(&self) -> Option<Vec<String>> {
         let output = self
             .run_command("ip", &["route", "list", "default"])
             .unwrap();

--- a/rita/src/rita_common/peer_listener/mod.rs
+++ b/rita/src/rita_common/peer_listener/mod.rs
@@ -267,18 +267,16 @@ fn receive_im_here(
         // this buffer is kept intentionally small to discard larger packets earlier rather than later
         loop {
             let mut datagram: [u8; 100] = [0; 100];
-            let (bytes_read, sock_addr) = match listen_interface
-                .multicast_socket
-                .recv_from(&mut datagram)
-            {
-                Ok(b) => b,
-                Err(e) => {
-                    trace!("Could not recv ImHere: {:?}", e);
-                    // TODO Consider we might want to remove interfaces that produce specific types
-                    // of errors from the active list
-                    break;
-                }
-            };
+            let (bytes_read, sock_addr) =
+                match listen_interface.multicast_socket.recv_from(&mut datagram) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        trace!("Could not recv ImHere: {:?}", e);
+                        // TODO Consider we might want to remove interfaces that produce specific types
+                        // of errors from the active list
+                        break;
+                    }
+                };
             trace!(
                 "Received {} bytes on multicast socket from {:?}",
                 bytes_read,

--- a/rita/src/rita_common/rita_loop/mod.rs
+++ b/rita/src/rita_common/rita_loop/mod.rs
@@ -198,8 +198,7 @@ impl Handler<Tick> for RitaLoop {
                         start.elapsed().subsec_nanos() / 1000000
                     );
                     TunnelManager::from_registry().send(PeersToContact::new(peers.unwrap())) // GetPeers never fails so unwrap is safe
-                })
-                .then(|_| Ok(())),
+                }).then(|_| Ok(())),
         );
 
         Ok(())


### PR DESCRIPTION
Previously we set the exit tunnel up every 5 seconds, I removed that and instead properly remembered system state, this adds back the minimum amount of checking and changes required to prevent problems with rouge dhcp reassignments and such. 