### PR TITLE
Query OS directly for free unused ports rather than directly managing them.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ target-mac
 **/*.db
 test.db-journal
 *.log
+
+# Ignore VIM artifacts
+*.sw*
+*.orig
+
 /scripts/staging_dir/
 integration-tests/private-key*
 integration-tests/rita-settings*

--- a/althea_kernel_interface/src/create_wg_key.rs
+++ b/althea_kernel_interface/src/create_wg_key.rs
@@ -7,6 +7,7 @@ use std::process::{Command, Stdio};
 
 use failure::Error;
 
+// TODO: Create a WireguardKey type
 #[derive(Debug)]
 pub struct WgKeypair {
     pub public: String,
@@ -55,4 +56,4 @@ impl KernelInterface {
     }
 }
 
-//Tested in CLU
+// Tested in CLU

--- a/althea_kernel_interface/src/lib.rs
+++ b/althea_kernel_interface/src/lib.rs
@@ -35,6 +35,7 @@ mod open_tunnel;
 mod openwrt_ubus;
 mod ping_check;
 mod setup_wg_if;
+mod udp_socket_table;
 pub mod wg_iface_counter;
 
 pub use counter::FilterTarget;

--- a/althea_kernel_interface/src/udp_socket_table.rs
+++ b/althea_kernel_interface/src/udp_socket_table.rs
@@ -1,0 +1,86 @@
+use super::KernelInterface;
+use std::fs::File;
+use std::io::prelude::*;
+use std::u16;
+
+use super::KernelInterfaceError;
+use failure::Error;
+
+/// Returns a kernel interface runtime error with the given message.
+fn runtime_error<T>(msg: &str) -> Result<T, Error> {
+    Err(KernelInterfaceError::RuntimeError(msg.to_string()).into())
+}
+
+/// Helper function for parsing out port number from local_address column
+fn parse_local_port(s: &str) -> Result<u16, Error> {
+    // second column in table contains local_address
+    let local_addr = match s.split_whitespace().nth(1) {
+        Some(addr) => addr,
+        None => return runtime_error("Error parsing local_address column!"),
+    };
+    // having a format like "00000000:14E9"
+    let port = match local_addr.split(":").nth(1) {
+        Some(port) => port,
+        None => return runtime_error("Error parsing local_address column!"),
+    };
+
+    match u16::from_str_radix(port, 16) {
+        Ok(port) => Ok(port),
+        Err(_) => runtime_error("Error parsing port from local_address column!"),
+    }
+}
+
+impl KernelInterface {
+    fn read_udp_socket_table(&self) -> Result<String, Error> {
+        let mut f = File::open("/proc/net/udp")?;
+        let mut contents = String::new();
+
+        f.read_to_string(&mut contents)?;
+
+        Ok(contents)
+    }
+
+    /// Returns list of ports in use as seen in the UDP socket table (/proc/net/udp)
+    pub fn used_ports(&self) -> Result<Vec<u16>, Error> {
+        let udp_sockets_table = self.read_udp_socket_table()?;
+        let mut lines = udp_sockets_table.split("\n");
+
+        lines.next(); // advance iterator to skip header
+
+        let ports: Vec<u16> = lines
+            .take_while(|line| line.len() > 0)  // until end of the table is reached,
+            .map(|line| parse_local_port(line)) // parse each udp port,
+            .filter_map(Result::ok) // only taking those which parsed successfully
+            .collect();
+
+        Ok(ports)
+    }
+}
+
+#[test]
+pub fn test_parse_local_port_on_valid_string_successful() {
+    let line = "1228: 00000000:14E9 00000000:0000 07 00000000:00000000 00:00000000 00000000  1000        0 34229668 2 ffff88007cb08800 0";
+
+    assert_eq!(parse_local_port(line).unwrap(), 5353)
+}
+
+#[test]
+pub fn test_parse_local_port_failure_on_totally_malformed_string() {
+    let line = "abcdefg";
+
+    assert!(parse_local_port(line).is_err())
+}
+
+#[test]
+pub fn test_parse_local_port_failure_on_malformed_local_address_column() {
+    let line = "1228: 00000000_14E9 00000000:0000 07 00000000:00000000 00:00000000 00000000  1000        0 34229668 2 ffff88007cb08800 0";
+
+    assert!(parse_local_port(line).is_err())
+}
+
+#[test]
+pub fn test_parse_local_port_failure_on_invalid_hex() {
+    let line = "1228: 00000000:FFFG 00000000:0000 07 00000000:00000000 00:00000000 00000000  1000        0 34229668 2 ffff88007cb08800 0";
+
+    assert!(parse_local_port(line).is_err())
+}

--- a/scripts/.git-hooks/pre-commit
+++ b/scripts/.git-hooks/pre-commit
@@ -3,18 +3,18 @@
 inconsistent_files=()
 
 while read file; do
-    if [ ${file: -3} == ".rs" ]; then
-        rustfmt --check $file 1>/dev/null;
+    if [ "${file: -3}" == ".rs" ]; then
+        rustfmt --check "$file" 1>/dev/null;
         if [ $? != 0 ]; then
             inconsistent_files+=($file);
         fi
     fi
-done < <(git diff --name-only --cached)
+done < <(git diff --name-only --cached --diff-filter=ACMRTUXB)
 
 if [ ${#inconsistent_files[@]} != 0 ]; then
     printf "Detected inconsistent formatting in: \n"
-    for file in ${inconsistent_files[@]}; do
-        printf "    rustfmt $file\n";
+    for file in "${inconsistent_files[@]}"; do
+        printf "    rustfmt %s\n" "$file";
     done
     printf "Or run 'cargo fmt --all' to fix formatting across the codebase.\n";
     exit 1


### PR DESCRIPTION
This is my first go at contributing to Althea. Here's an attempt at solving #177 . Here I took the route of using a newer crate called [`netstat`](https://github.com/ivxvm/netstat-rs) to query the OS directly for unused UDP ports.