### PR TITLE
Add error handling for old Babel versions

### DIFF
--- a/babel_monitor/src/lib.rs
+++ b/babel_monitor/src/lib.rs
@@ -168,7 +168,7 @@ impl<T: Read + Write> Babel<T> {
     }
 
     pub fn set_metric_factor(&mut self, new_factor: u32) -> Result<(), Error> {
-        let _babel_output = self.command(&format!("metric-factor {}", new_factor));
+        let _babel_output = self.command(&format!("metric-factor {}", new_factor))?;
         Ok(())
     }
 

--- a/clu/src/lib.rs
+++ b/clu/src/lib.rs
@@ -113,20 +113,22 @@ fn linux_init(config: Arc<RwLock<settings::RitaSettingsStruct>>) -> Result<(), E
 
         // Fall back and migrate from own_ip if possible, TODO: REMOVE IN ALPHA 11
         None => match own_ip_option {
-            Some(existing_own_ip) => if validate_mesh_ip(&existing_own_ip) {
-                info!(
-                    "Found existing compat own_ip field {}, migrating to mesh_ip",
-                    existing_own_ip
-                );
-                network_settings.mesh_ip = Some(existing_own_ip);
-            } else {
-                warn!(
+            Some(existing_own_ip) => {
+                if validate_mesh_ip(&existing_own_ip) {
+                    info!(
+                        "Found existing compat own_ip field {}, migrating to mesh_ip",
+                        existing_own_ip
+                    );
+                    network_settings.mesh_ip = Some(existing_own_ip);
+                } else {
+                    warn!(
                     "Existing compat own_ip value {} is invalid, generating a new mesh IP and migrating to mesh_ip",
                     existing_own_ip
                     );
-                network_settings.mesh_ip =
-                    Some(linux_generate_mesh_ip().expect("failed to generate a new mesh IP"));
-            },
+                    network_settings.mesh_ip =
+                        Some(linux_generate_mesh_ip().expect("failed to generate a new mesh IP"));
+                }
+            }
             None => {
                 info!("There's no mesh IP configured, generating");
                 network_settings.mesh_ip =
@@ -195,6 +197,15 @@ fn linux_init(config: Arc<RwLock<settings::RitaSettingsStruct>>) -> Result<(), E
 
     let local_fee = config.get_local_fee();
     let metric_factor = config.get_metric_factor();
+    if local_fee == 0 {
+        warn!("THIS NODE IS GIVING BANDWIDTH AWAY FOR FREE. PLEASE SET local_fee TO A NON-ZERO VALUE TO DISABLE THIS WARNING.");
+    }
+    if metric_factor == 0 {
+        warn!("THIS NODE DOESN'T PAY ATTENTION TO ROUTE QUALITY - IT'LL CHOOSE THE CHEAPEST ROUTE EVEN IF IT'S THE WORST LINK AROUND. PLEASE SET metric_factor TO A NON-ZERO VALUE TO DISABLE THIS WARNING.");
+    }
+    if metric_factor > 2000000 {
+        warn!("THIS NODE DOESN'T PAY ATTENTION TO ROUTE PRICE - IT'LL CHOOSE THE BEST ROUTE EVEN IF IT COSTS WAY TOO MUCH. PLEASE SET metric_factor TO A LOWER VALUE TO DISABLE THIS WARNING.");
+    }
 
     let stream = TcpStream::connect::<SocketAddr>(
         format!("[::1]:{}", config.get_network().babel_port).parse()?,
@@ -204,14 +215,14 @@ fn linux_init(config: Arc<RwLock<settings::RitaSettingsStruct>>) -> Result<(), E
 
     babel.start_connection()?;
 
-    babel.set_local_fee(local_fee)?;
-    if local_fee == 0 {
-        warn!("THIS NODE IS GIVING BANDWIDTH AWAY FOR FREE. PLEASE SET local_fee TO A NON-ZERO VALUE TO DISABLE THIS WARNING.");
+    match babel.set_local_fee(local_fee) {
+        Ok(()) => info!("Local fee set to {}", local_fee),
+        Err(e) => warn!("Could not set local fee! {:?}", e),
     }
 
-    babel.set_metric_factor(metric_factor)?;
-    if metric_factor == 0 {
-        warn!("THIS NODE DOESN'T PAY ATTENTION TO ROUTE QUALITY - IT'LL CHOOSE THE CHEAPEST ROUTE EVEN IF IT'S THE WORST LINK AROUND. PLEASE SET metric_factor TO A NON-ZERO VALUE TO DISABLE THIS WARNING.");
+    match babel.set_metric_factor(metric_factor) {
+        Ok(()) => info!("Metric factor set to {}", metric_factor),
+        Err(e) => warn!("Could not set metric factor! {:?}", e),
     }
 
     Ok(())
@@ -242,20 +253,22 @@ fn linux_exit_init(config: Arc<RwLock<settings::RitaExitSettingsStruct>>) -> Res
 
         // Fall back and migrate from own_ip if possible, TODO: REMOVE IN ALPHA 11
         None => match own_ip_option {
-            Some(existing_own_ip) => if validate_mesh_ip(&existing_own_ip) {
-                info!(
-                    "Found existing compat own_ip field {}, migrating to mesh_ip",
-                    existing_own_ip
-                );
-                network_settings.mesh_ip = Some(existing_own_ip);
-            } else {
-                warn!(
+            Some(existing_own_ip) => {
+                if validate_mesh_ip(&existing_own_ip) {
+                    info!(
+                        "Found existing compat own_ip field {}, migrating to mesh_ip",
+                        existing_own_ip
+                    );
+                    network_settings.mesh_ip = Some(existing_own_ip);
+                } else {
+                    warn!(
                     "Existing compat own_ip value {} is invalid, generating a new mesh IP and migrating to mesh_ip",
                     existing_own_ip
                     );
-                network_settings.mesh_ip =
-                    Some(linux_generate_mesh_ip().expect("failed to generate a new mesh IP"));
-            },
+                    network_settings.mesh_ip =
+                        Some(linux_generate_mesh_ip().expect("failed to generate a new mesh IP"));
+                }
+            }
             None => {
                 info!("There's no mesh IP configured, generating");
                 network_settings.mesh_ip =

--- a/rita/src/rita_common/dashboard/network_endpoints.rs
+++ b/rita/src/rita_common/dashboard/network_endpoints.rs
@@ -178,6 +178,7 @@ pub fn set_local_fee(path: Path<u32>) -> Box<Future<Item = HttpResponse, Error =
     ) {
         Ok(s) => s,
         Err(e) => {
+            error!("Failed to set local fee! {:?}", e);
             ret.insert(
                 "error".to_owned(),
                 "Could not create a socket for connecting to Babel".to_owned(),
@@ -195,6 +196,7 @@ pub fn set_local_fee(path: Path<u32>) -> Box<Future<Item = HttpResponse, Error =
     let mut babel = Babel::new(stream);
 
     if let Err(e) = babel.start_connection() {
+        error!("Failed to set local fee! {:?}", e);
         ret.insert("error".to_owned(), "Could not connect to Babel".to_owned());
         ret.insert("rust_error".to_owned(), format!("{:?}", e));
 
@@ -206,6 +208,7 @@ pub fn set_local_fee(path: Path<u32>) -> Box<Future<Item = HttpResponse, Error =
     }
 
     if let Err(e) = babel.set_local_fee(new_fee) {
+        error!("Failed to set local fee! {:?}", e);
         ret.insert(
             "error".to_owned(),
             "Failed to ask Babel to set the proposed fee".to_owned(),
@@ -242,6 +245,7 @@ pub fn set_metric_factor(path: Path<u32>) -> Box<Future<Item = HttpResponse, Err
     ) {
         Ok(s) => s,
         Err(e) => {
+            error!("Failed to set metric factor! {:?}", e);
             ret.insert(
                 "error".to_owned(),
                 "Could not create a socket for connecting to Babel".to_owned(),
@@ -259,6 +263,7 @@ pub fn set_metric_factor(path: Path<u32>) -> Box<Future<Item = HttpResponse, Err
     let mut babel = Babel::new(stream);
 
     if let Err(e) = babel.start_connection() {
+        error!("Failed to set metric factor! {:?}", e);
         ret.insert("error".to_owned(), "Could not connect to Babel".to_owned());
         ret.insert("rust_error".to_owned(), format!("{:?}", e));
 
@@ -270,6 +275,7 @@ pub fn set_metric_factor(path: Path<u32>) -> Box<Future<Item = HttpResponse, Err
     }
 
     if let Err(e) = babel.set_metric_factor(new_factor) {
+        error!("Failed to set metric factor! {:?}", e);
         ret.insert(
             "error".to_owned(),
             "Failed to ask Babel to set the proposed factor".to_owned(),


### PR DESCRIPTION
It's possible that when updating a Rita update may succeed and a babel update may fail causing Rita to crash when trying to interact with older Rita, this fixes that by adding handling for setting the price on startup. 