### PR TITLE
The + is a valid char in wgkey parsing

### DIFF
--- a/althea_kernel_interface/src/wg_iface_counter.rs
+++ b/althea_kernel_interface/src/wg_iface_counter.rs
@@ -28,9 +28,9 @@ impl KernelInterface {
         }
 
         lazy_static! {
-            static ref RE: Regex =
-                Regex::new(r"(?P<key>[/=0-9a-zA-Z]+)\t(?P<download>[0-9]+)\t(?P<upload>[0-9]+)\n*")
-                    .expect("Unable to compile regular expression");
+            static ref RE: Regex = Regex::new(
+                r"(?P<key>[+/=0-9a-zA-Z]+)\t(?P<download>[0-9]+)\t(?P<upload>[0-9]+)\n*"
+            ).expect("Unable to compile regular expression");
         }
 
         let mut result = HashMap::new();


### PR DESCRIPTION
This is causing errors in counting exit balances, it only seems to cause issues
with some keys so it's easy to see how it got missed during testing.