### PR TITLE
Fix dynamic fee comptuation and add netid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ version = "0.1.0"
 dependencies = [
  "actix 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "clarity 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clarity 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "eui48 0.4.0 (git+https://github.com/althea-mesh/eui48)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -298,7 +298,7 @@ version = "0.1.0"
 dependencies = [
  "actix 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "clarity 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clarity 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -329,6 +329,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "byte-tools"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bytecount"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -367,9 +372,10 @@ dependencies = [
 
 [[package]]
 name = "clarity"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "bytecount 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -398,7 +404,7 @@ dependencies = [
  "althea_kernel_interface 0.1.0",
  "althea_types 0.1.0",
  "babel_monitor 0.1.0",
- "clarity 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clarity 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipgen 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -941,7 +947,7 @@ source = "git+https://github.com/althea-mesh/guac_rs#2bc1f3ed734155ca073dd95943a
 dependencies = [
  "actix-web 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "clarity 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clarity 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1956,7 +1962,7 @@ dependencies = [
  "babel_monitor 0.1.0",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "clarity 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clarity 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "clu 0.0.1",
  "config 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2195,7 +2201,7 @@ version = "0.1.0"
 dependencies = [
  "althea_kernel_interface 0.1.0",
  "althea_types 0.1.0",
- "clarity 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clarity 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "eui48 0.4.0 (git+https://github.com/althea-mesh/eui48)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2947,12 +2953,13 @@ dependencies = [
 "checksum bufstream 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byte-tools 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "980479e6fde23246dfb54d47580d66b4e99202e7579c5eaa9fe10ecb5ebd2182"
+"checksum bytecount 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b92204551573580e078dc80017f36a213eb77a0450e4ddd8cfa0f3f2d1f0178f"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
 "checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
-"checksum clarity 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "aca8931b88bdb11adc873ae649544a1bf1f13b30d73416670fe787ead933920c"
+"checksum clarity 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "49024389b35d3abcce94de9d94dc0b7c520c7170505d7ac2afa29f4519cdf26a"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum colored 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc0a60679001b62fb628c4da80e574b9645ab4646056d7c9018885efffe45533"
 "checksum config 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13490293b8a84cc82cd531da41adeae82cd9eaa40e926ac18865aa361f9c9f60"

--- a/rita/src/rita_common/dashboard/wallet.rs
+++ b/rita/src/rita_common/dashboard/wallet.rs
@@ -18,12 +18,11 @@ pub fn withdraw(path: Path<(Address, u64)>) -> Box<Future<Item = HttpResponse, E
         data: Vec::new(),
         signature: None,
     };
-    // TODO figure out the whole network id thing
     let transaction_signed = tx.sign(
         &payment_settings
             .eth_private_key
             .expect("No private key configured!"),
-        None,
+        payment_settings.net_version,
     );
 
     let transaction_bytes = match transaction_signed.to_bytes() {

--- a/rita/src/rita_common/payment_controller/mod.rs
+++ b/rita/src/rita_common/payment_controller/mod.rs
@@ -130,7 +130,6 @@ impl PaymentController {
 
         let tx = Transaction {
             nonce: nonce,
-            // TODO: replace with sane defaults
             gas_price: gas_price,
             gas_limit: "21000".parse().unwrap(),
             to: pmt.to.eth_address.clone(),
@@ -138,12 +137,11 @@ impl PaymentController {
             data: Vec::new(),
             signature: None,
         };
-        // TODO figure out the whole network id thing
         let transaction_signed = tx.sign(
             &payment_settings
                 .eth_private_key
                 .expect("No private key configured!"),
-            None,
+            payment_settings.net_version,
         );
 
         let transaction_bytes = match transaction_signed.to_bytes() {

--- a/settings/src/lib.rs
+++ b/settings/src/lib.rs
@@ -241,14 +241,18 @@ fn default_pay_threshold() -> Int256 {
     840000000000000u64.into()
 }
 
+fn default_dynamic_fee_multiplier() -> u32 {
+    10
+}
+
 /// This struct is used by both rita and rita_exit to configure the dummy payment controller and
 /// debt keeper
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct PaymentSettings {
     /// For non-channel payments only, determines how much to multiply the nominal gas price
     /// to get the pay_threshold values and then again for the close_threshold
-    #[serde(default)]
-    pub dynamic_fee_multiplier: u16,
+    #[serde(default = "default_dynamic_fee_multiplier")]
+    pub dynamic_fee_multiplier: u32,
     /// The threshold above which we will kick off a payment
     #[serde(
         skip_serializing,
@@ -283,6 +287,8 @@ pub struct PaymentSettings {
     pub nonce: Uint256,
     #[serde(skip_serializing, skip_deserializing)]
     pub gas_price: Uint256,
+    #[serde(skip_serializing, skip_deserializing)]
+    pub net_version: Option<u64>,
     /// A list of nodes to query for blockchain data
     /// this is kept seperate from the version for DAO settings node
     /// list in order to allow for the DAO and payments to exist on different
@@ -312,6 +318,7 @@ impl Default for PaymentSettings {
             balance: 0.into(),
             nonce: 0.into(),
             gas_price: 10000000000u64.into(), // 10 gwei
+            net_version: None,
             node_list: Vec::new(),
         }
     }


### PR DESCRIPTION
Fix the computation of dyanmic fees to have an actual default value of 10
and use a network id that's provided by the full node to prevent transactions
from being portable across network forks.