### PR TITLE
Validate that transactions are actually real

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ dependencies = [
  "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazycell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -469,8 +469,11 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "crossbeam"
@@ -943,7 +946,7 @@ dependencies = [
 [[package]]
 name = "guac_core"
 version = "0.1.0"
-source = "git+https://github.com/althea-mesh/guac_rs#2bc1f3ed734155ca073dd95943abb67a36f24c11"
+source = "git+https://github.com/althea-mesh/guac_rs#a7b2a838fe34504aac44e82f83741c63af1a621b"
 dependencies = [
  "actix-web 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1199,7 +1202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazycell"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1248,7 +1251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "crc32fast 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc32fast 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1363,7 +1366,7 @@ dependencies = [
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazycell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2966,7 +2969,7 @@ dependencies = [
 "checksum cookie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1465f8134efa296b4c19db34d909637cb2bf0f7aaf21299e23e18fa29ac557cf"
 "checksum core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980"
 "checksum core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa"
-"checksum crc32fast 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e0e685559fa8bccfa46afd0f876047ee5d87c536d71d0c2b3a08cc9e880f73eb"
+"checksum crc32fast 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e91d5240c6975ef33aeb5f148f35275c25eda8e8a5f95abe421978b05b8bf192"
 "checksum crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24ce9782d4d5c53674646a6a4c1863a21a8fc0cb649b3c94dfc16e45071dea19"
 "checksum crossbeam-channel 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7b85741761b7f160bc5e7e0c14986ef685b7f8bf9b7ad081c60c604bb4649827"
 "checksum crossbeam-deque 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4fe1b6f945f824c7a25afe44f62e25d714c0cc523f8e99d8db5cd1026e1269d3"
@@ -3047,7 +3050,7 @@ dependencies = [
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
-"checksum lazycell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddba4c30a78328befecec92fc94970e53b3ae385827d28620f0f5bb2493081e0"
+"checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum lettre 0.9.0 (git+https://github.com/lettre/lettre.git)" = "<none>"
 "checksum lettre_email 0.9.0 (git+https://github.com/lettre/lettre.git)" = "<none>"
 "checksum libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)" = "10923947f84a519a45c8fefb7dd1b3e8c08747993381adee176d7a82b4195311"

--- a/althea_types/src/interop.rs
+++ b/althea_types/src/interop.rs
@@ -168,11 +168,14 @@ impl Message for LocalIdentity {
     type Result = ();
 }
 
-/// This is a stand-in for channel updates. Completely insecure, but allows us to
-/// track how much people would be paying each other if channels were implemented.
+/// This is a stand-in for channel updates. representing a payment
+/// when completed it contains a txid from a published transaction
+/// that should be validated against the blockchain
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
 pub struct PaymentTx {
     pub to: Identity,
     pub from: Identity,
     pub amount: Uint256,
+    // populated when transaction is published
+    pub txid: Option<Uint256>,
 }

--- a/rita/src/rita_common/debt_keeper/mod.rs
+++ b/rita/src/rita_common/debt_keeper/mod.rs
@@ -167,7 +167,8 @@ impl Handler<SendUpdate> for DebtKeeper {
                             Some(id) => id,
                             None => bail!("Identity has no mesh IP ready yet"),
                         },
-                        amount,
+                        amount: amount,
+                        txid: None, // not yet published
                     })),
                 DebtAction::None => {}
             }

--- a/rita/src/rita_common/payment_controller/mod.rs
+++ b/rita/src/rita_common/payment_controller/mod.rs
@@ -97,7 +97,7 @@ impl PaymentController {
 
     /// This is called by the other modules in Rita to make payments. It sends a
     /// PaymentTx to the `mesh_ip` in its `to` field.
-    pub fn make_payment(&mut self, pmt: PaymentTx) -> Result<(), Error> {
+    pub fn make_payment(&mut self, mut pmt: PaymentTx) -> Result<(), Error> {
         let payment_settings = SETTING.get_payment();
         let balance = payment_settings.balance.clone();
         let nonce = payment_settings.nonce.clone();
@@ -153,7 +153,9 @@ impl PaymentController {
 
         let futures_chain = Box::new(transaction_status.then(move |outcome| {
             match outcome {
-                Ok(_tx_id) => {
+                Ok(tx_id) => {
+                    // add published txid to submission
+                    pmt.txid = Some(tx_id);
                     Either::A(
                         client::post(&neighbor_url)
                             .json(&pmt)


### PR DESCRIPTION
This adds transaction validation to the payments system, when we
get a payment from a peer we will go and look it up on our own
full node and check that it satisfies all of the properties
required to make it a valid payment to us for the amount expected.

The biggest issue with this commit is that it adds more failure
conditions to a payment being accepted but there's still no resolution
to how to re-converge on lost payments or otherwise 'try again' and
make sure things went through.

I think a good solution might be some sort of watcher that will retry
failed txid validations a few times in the case of some spurious failure
that should reduce things to malicious behavior and uncommon enough edgecases
as to not be an issue.