### PR TITLE
Move traffic update to vec

### DIFF
--- a/rita/src/rita_client/traffic_watcher/mod.rs
+++ b/rita/src/rita_client/traffic_watcher/mod.rs
@@ -15,7 +15,7 @@ use std::io::{Read, Write};
 use std::net::{IpAddr, SocketAddr, TcpStream};
 use std::time::{Duration, SystemTime};
 
-use crate::rita_common::debt_keeper::{DebtKeeper, TrafficUpdate};
+use crate::rita_common::debt_keeper::{DebtKeeper, Traffic, TrafficUpdate};
 use crate::rita_common::tunnel_manager::Neighbor;
 use crate::KI;
 use crate::SETTING;
@@ -196,8 +196,10 @@ pub fn watch<T: Read + Write>(
     info!("Total client debt of {} this round", owes_exit);
 
     let exit_update = TrafficUpdate {
-        from: exit.clone(),
-        amount: owes_exit,
+        traffic: vec![Traffic {
+            from: exit.clone(),
+            amount: owes_exit,
+        }],
     };
 
     DebtKeeper::from_registry().do_send(exit_update);

--- a/rita/src/rita_common/debt_keeper/mod.rs
+++ b/rita/src/rita_common/debt_keeper/mod.rs
@@ -131,17 +131,23 @@ impl Handler<PaymentFailed> for DebtKeeper {
     }
 }
 
-#[derive(Message)]
-pub struct TrafficUpdate {
+pub struct Traffic {
     pub from: Identity,
     pub amount: Int256,
+}
+
+#[derive(Message)]
+pub struct TrafficUpdate {
+    pub traffic: Vec<Traffic>,
 }
 
 impl Handler<TrafficUpdate> for DebtKeeper {
     type Result = ();
 
     fn handle(&mut self, msg: TrafficUpdate, _: &mut Context<Self>) -> Self::Result {
-        self.traffic_update(&msg.from, msg.amount)
+        for t in msg.traffic.iter() {
+            self.traffic_update(&t.from, t.amount.clone());
+        }
     }
 }
 

--- a/rita/src/rita_common/traffic_watcher/mod.rs
+++ b/rita/src/rita_common/traffic_watcher/mod.rs
@@ -14,6 +14,7 @@ use babel_monitor::Babel;
 
 use crate::rita_common::debt_keeper;
 use crate::rita_common::debt_keeper::DebtKeeper;
+use crate::rita_common::debt_keeper::Traffic;
 
 use num256::Int256;
 
@@ -290,16 +291,18 @@ pub fn watch<T: Read + Write>(mut babel: Babel<T>, neighbors: &Vec<Neighbor>) ->
         total_income
     );
 
+    let mut traffic_vec = Vec::new();
     for (from, amount) in debts {
         trace!("collated debt for {} is {}", from.mesh_ip, amount);
-
-        let update = debt_keeper::TrafficUpdate {
-            from: from.clone(),
-            amount,
-        };
-
-        DebtKeeper::from_registry().do_send(update);
+        traffic_vec.push(Traffic {
+            from: from,
+            amount: amount,
+        });
     }
+    let update = debt_keeper::TrafficUpdate {
+        traffic: traffic_vec,
+    };
+    DebtKeeper::from_registry().do_send(update);
 
     // check if we are a gateway
     let gateway = match SETTING.get_network().external_nic {

--- a/rita/src/rita_exit/network_endpoints/mod.rs
+++ b/rita/src/rita_exit/network_endpoints/mod.rs
@@ -24,7 +24,7 @@ use std::net::SocketAddr;
 pub fn setup_request(
     their_id: (Json<ExitClientIdentity>, HttpRequest),
 ) -> Box<dyn Future<Item = Json<ExitState>, Error = Error>> {
-    trace!("Received requester identity, {:?}", their_id.0);
+    trace!("Received requester identity for setup, {:?}", their_id.0);
     let remote_mesh_socket: SocketAddr = their_id
         .1
         .connection_info()
@@ -54,7 +54,7 @@ pub fn setup_request(
 pub fn status_request(
     their_id: Json<ExitClientIdentity>,
 ) -> impl Future<Item = Json<ExitState>, Error = Error> {
-    trace!("Received requester identity, {:?}", their_id);
+    trace!("Received requester identity for status, {:?}", their_id);
     DbClient::from_registry()
         .send(ClientStatus(their_id.into_inner()))
         .from_err()

--- a/rita/src/rita_exit/traffic_watcher/mod.rs
+++ b/rita/src/rita_exit/traffic_watcher/mod.rs
@@ -18,6 +18,7 @@ use babel_monitor::Babel;
 
 use crate::rita_common::debt_keeper;
 use crate::rita_common::debt_keeper::DebtKeeper;
+use crate::rita_common::debt_keeper::Traffic;
 
 use num256::Int256;
 
@@ -267,14 +268,17 @@ pub fn watch<T: Read + Write>(
         Err(e) => warn!("Getting clients failed with {:?}", e),
     }
 
+    let mut traffic_vec = Vec::new();
     for (from, amount) in debts {
-        let update = debt_keeper::TrafficUpdate {
-            from: from.clone(),
-            amount,
-        };
-
-        DebtKeeper::from_registry().do_send(update);
+        traffic_vec.push(Traffic {
+            from: from,
+            amount: amount,
+        })
     }
+    let update = debt_keeper::TrafficUpdate {
+        traffic: traffic_vec,
+    };
+    DebtKeeper::from_registry().do_send(update);
 
     Ok(())
 }


### PR DESCRIPTION
Instead of sending traffic updates as invividual messages we now
send them as vectors, this should help avoid some actix mailbox
issues we where seeing in debug builds and generally make things
more efficient as we'll spend less time task switching.