### PR TITLE
Optionize low balance warning

### DIFF
--- a/althea_types/src/interop.rs
+++ b/althea_types/src/interop.rs
@@ -189,7 +189,7 @@ pub struct ExitClientIdentity {
     pub wg_port: u16,
     pub global: Identity,
     pub reg_details: ExitRegistrationDetails,
-    pub low_balance: bool,
+    pub low_balance: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Copy)]

--- a/rita/src/rita_client/exit_manager/mod.rs
+++ b/rita/src/rita_client/exit_manager/mod.rs
@@ -242,7 +242,7 @@ pub fn exit_setup_request(
         },
         wg_port: SETTING.get_exit_client().wg_listen_port,
         reg_details,
-        low_balance: low_balance(),
+        low_balance: None,
     };
 
     let endpoint = SocketAddr::new(exit_server, current_exit.registration_port);
@@ -300,7 +300,7 @@ fn exit_status_request(exit: String) -> impl Future<Item = (), Error = Error> {
         },
         wg_port: SETTING.get_exit_client().wg_listen_port,
         reg_details: SETTING.get_exit_client().reg_details.clone().unwrap(),
-        low_balance: balance_notification,
+        low_balance: Some(balance_notification),
     };
 
     let endpoint = SocketAddr::new(exit_server, current_exit.registration_port);

--- a/rita/src/rita_exit/db_client/mod.rs
+++ b/rita/src/rita_exit/db_client/mod.rs
@@ -907,7 +907,7 @@ fn low_balance_notification(
         secs_since_unix_epoch() - their_record.last_balance_warning_time;
 
     match (client.low_balance, config) {
-        (true, Some(ExitVerifSettings::Phone(val))) => match (
+        (Some(true), Some(ExitVerifSettings::Phone(val))) => match (
             client.reg_details.phone.clone(),
             time_since_last_notification > i64::from(val.balance_notification_interval),
         ) {
@@ -928,7 +928,7 @@ fn low_balance_notification(
             (Some(_), false) => {}
             (None, _) => error!("Client is registered but has no phone number!"),
         },
-        (true, Some(ExitVerifSettings::Email(val))) => match (
+        (Some(true), Some(ExitVerifSettings::Email(val))) => match (
             client.reg_details.email.clone(),
             time_since_last_notification > i64::from(val.balance_notification_interval),
         ) {
@@ -949,8 +949,7 @@ fn low_balance_notification(
             (Some(_), false) => {}
             (None, _) => error!("Client is registered but has no phone number!"),
         },
-        (true, None) => {}
-        (false, _) => {}
+        (_, _) => {}
     }
 }
 


### PR DESCRIPTION
This allows old rouers to still sign up correctly with new exits and
generally sets things up for full backwards compatibility.