### PR TITLE
Handle slow linklocal address generation

### DIFF
--- a/althea_kernel_interface/src/lib.rs
+++ b/althea_kernel_interface/src/lib.rs
@@ -40,11 +40,35 @@ pub use crate::create_wg_key::WgKeypair;
 pub use crate::exit_server_tunnel::ExitClient;
 
 use failure::Error;
+use std::net::AddrParseError;
+use std::string::FromUtf8Error;
 
 #[derive(Debug, Fail)]
 pub enum KernelInterfaceError {
     #[fail(display = "Runtime Error: {:?}", _0)]
     RuntimeError(String),
+    #[fail(display = "No interface by the name: {:?}", _0)]
+    NoInterfaceError(String),
+    #[fail(display = "Address isn't ready yet: {:?}", _0)]
+    AddressNotReadyError(String),
+}
+
+impl From<FromUtf8Error> for KernelInterfaceError {
+    fn from(e: FromUtf8Error) -> Self {
+        KernelInterfaceError::RuntimeError(format!("{:?}", e).to_string())
+    }
+}
+
+impl From<Error> for KernelInterfaceError {
+    fn from(e: Error) -> Self {
+        KernelInterfaceError::RuntimeError(format!("{:?}", e).to_string())
+    }
+}
+
+impl From<AddrParseError> for KernelInterfaceError {
+    fn from(e: AddrParseError) -> Self {
+        KernelInterfaceError::RuntimeError(format!("{:?}", e).to_string())
+    }
 }
 
 #[cfg(test)]

--- a/rita/src/client.rs
+++ b/rita/src/client.rs
@@ -302,8 +302,16 @@ fn main() {
             .route("/blockchain/get/", Method::GET, get_system_blockchain)
             .route("/nickname/get/", Method::GET, get_nickname)
             .route("/nickname/set/", Method::POST, set_nickname)
-            .route("/low_balance_notification", Method::GET, get_low_balance_notification)
-            .route("/low_balance_notification/{status}", Method::POST, set_low_balance_notification)
+            .route(
+                "/low_balance_notification",
+                Method::GET,
+                get_low_balance_notification,
+            )
+            .route(
+                "/low_balance_notification/{status}",
+                Method::POST,
+                set_low_balance_notification,
+            )
             .route("/wipe", Method::POST, wipe)
     })
     .workers(1)

--- a/rita/src/rita_common/peer_listener/message.rs
+++ b/rita/src/rita_common/peer_listener/message.rs
@@ -185,7 +185,7 @@ fn test_decode_imhere_with_wrong_magic() {
     match PeerMessage::decode(&[1, 2, 3, 4]) {
         Ok(msg) => assert!(false, "Unexpected success {:?}", msg),
         Err(MessageError::InvalidMagic) => assert!(true),
-        Err(_) => panic!("Invalid error"),
+        Err(e) => panic!("Invalid error {:?}", e),
     }
 }
 


### PR DESCRIPTION
I've got a hunch that this is what's stopping devices from coming back
properly in some scenarios, so lets try a fix.