### PR TITLE
The importaning

### DIFF
--- a/clu/src/lib.rs
+++ b/clu/src/lib.rs
@@ -373,8 +373,10 @@ pub fn exit_init(platform: &str, settings: Arc<RwLock<settings::exit::RitaExitSe
     );
 }
 
+#[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::validate_mesh_ip;
+    use std::net::IpAddr;
 
     #[test]
     fn test_validate_mesh_ip() {

--- a/rita/src/rita_client/dashboard/eth_private_key.rs
+++ b/rita/src/rita_client/dashboard/eth_private_key.rs
@@ -1,5 +1,12 @@
-use super::*;
+use crate::ARGS;
+use crate::KI;
+use crate::SETTING;
+use ::actix_web::{HttpRequest, HttpResponse, Json};
 use clarity::PrivateKey;
+use failure::Error;
+use settings::FileWrite;
+use settings::RitaCommonSettings;
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Default, Clone, Debug)]
 pub struct EthPrivateKey {

--- a/rita/src/rita_client/dashboard/exits.rs
+++ b/rita/src/rita_client/dashboard/exits.rs
@@ -1,9 +1,27 @@
 //! The Exit info endpoint gathers infromation about exit status and presents it to the dashbaord.
 
-use super::*;
-
+use crate::rita_client::exit_manager::exit_setup_request;
+use crate::rita_common::dashboard::Dashboard;
 use crate::ARGS;
+use crate::KI;
+use crate::SETTING;
+use ::actix::prelude::*;
+use ::actix_web::http::StatusCode;
+use ::actix_web::AsyncResponder;
+use ::actix_web::Path;
+use ::actix_web::{HttpRequest, HttpResponse, Json};
+use althea_types::ExitState;
+use babel_monitor::Babel;
+use failure::Error;
+use futures::{future, Future};
+use reqwest;
+use settings::client::{ExitServer, RitaClientSettings};
 use settings::FileWrite;
+use settings::RitaCommonSettings;
+use std::boxed::Box;
+use std::collections::HashMap;
+use std::net::{SocketAddr, TcpStream};
+use std::time::Duration;
 
 #[derive(Serialize)]
 pub struct ExitInfo {

--- a/rita/src/rita_client/dashboard/interfaces.rs
+++ b/rita/src/rita_client/dashboard/interfaces.rs
@@ -1,7 +1,18 @@
 //! A generalized interface for modifying networking interface assignments using UCI
-use super::*;
+use crate::rita_common::peer_listener::PeerListener;
+use crate::rita_common::peer_listener::{Listen, UnListen};
 use crate::ARGS;
+use crate::KI;
+use crate::SETTING;
+use ::actix::prelude::*;
+use ::actix_web::{HttpRequest, HttpResponse, Json};
+use failure::Error;
+use futures::Future;
 use settings::FileWrite;
+use settings::RitaCommonSettings;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use tokio::timer::Delay;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct InterfaceToSet {

--- a/rita/src/rita_client/dashboard/logging.rs
+++ b/rita/src/rita_client/dashboard/logging.rs
@@ -1,4 +1,12 @@
-use super::*;
+use crate::ARGS;
+use crate::KI;
+use crate::SETTING;
+use ::actix_web::http::StatusCode;
+use ::actix_web::{HttpResponse, Path};
+use failure::Error;
+use log::LevelFilter;
+use settings::client::RitaClientSettings;
+use settings::FileWrite;
 
 pub fn remote_logging(path: Path<bool>) -> Result<HttpResponse, Error> {
     let enabled = path.into_inner();

--- a/rita/src/rita_client/dashboard/mesh_ip.rs
+++ b/rita/src/rita_client/dashboard/mesh_ip.rs
@@ -1,4 +1,12 @@
-use super::*;
+use crate::ARGS;
+use crate::KI;
+use crate::SETTING;
+use ::actix_web::{HttpRequest, HttpResponse, Json};
+use failure::Error;
+use settings::FileWrite;
+use settings::RitaCommonSettings;
+use std::collections::HashMap;
+use std::net::IpAddr;
 
 pub fn get_mesh_ip(_req: HttpRequest) -> Result<HttpResponse, Error> {
     debug!("/mesh_ip GET hit");

--- a/rita/src/rita_client/dashboard/mod.rs
+++ b/rita/src/rita_client/dashboard/mod.rs
@@ -4,51 +4,6 @@
 //!
 //! For more documentation on specific functions see the router-dashboard file in the docs folder
 
-use ::actix::prelude::*;
-use ::actix_web::http::StatusCode;
-use ::actix_web::Path;
-use ::actix_web::{AsyncResponder, HttpRequest, HttpResponse, Json};
-
-use failure::Error;
-
-use tokio::timer::Delay;
-
-use serde_json::Value;
-
-use std::boxed::Box;
-use std::collections::HashMap;
-use std::net::IpAddr;
-use std::net::{SocketAddr, TcpStream};
-use std::time::{Duration, Instant};
-
-use futures::future;
-use futures::Future;
-
-use log::LevelFilter;
-
-use reqwest;
-
-use babel_monitor::Babel;
-
-use crate::rita_common::dashboard::Dashboard;
-use crate::rita_common::debt_keeper::{DebtKeeper, Dump, NodeDebtData};
-use crate::rita_common::peer_listener::PeerListener;
-use crate::rita_common::peer_listener::{Listen, UnListen};
-use crate::rita_common::tunnel_manager::{GetNeighbors, Neighbor, TunnelManager};
-use althea_types::Identity;
-
-use crate::SETTING;
-use settings::client::ExitServer;
-use settings::client::RitaClientSettings;
-use settings::RitaCommonSettings;
-
-use crate::KI;
-
-use num256::Int256;
-
-use crate::rita_client::exit_manager::exit_setup_request;
-use althea_types::ExitState;
-
 pub mod eth_private_key;
 pub mod exits;
 pub mod interfaces;
@@ -58,6 +13,3 @@ pub mod neighbors;
 pub mod notifications;
 pub mod system_chain;
 pub mod wifi;
-
-use crate::ARGS;
-use settings::FileWrite;

--- a/rita/src/rita_client/dashboard/neighbors.rs
+++ b/rita/src/rita_client/dashboard/neighbors.rs
@@ -1,6 +1,21 @@
-use super::*;
+use crate::rita_common::dashboard::Dashboard;
+use crate::rita_common::debt_keeper::{DebtKeeper, Dump, NodeDebtData};
+use crate::rita_common::tunnel_manager::{GetNeighbors, Neighbor, TunnelManager};
+use crate::SETTING;
+use ::actix::prelude::*;
+use ::actix_web::AsyncResponder;
+use ::actix_web::{HttpRequest, Json};
+use althea_types::Identity;
 use arrayvec::ArrayString;
-use num256::Uint256;
+use babel_monitor::Babel;
+use failure::Error;
+use futures::Future;
+use num256::{Int256, Uint256};
+use settings::client::RitaClientSettings;
+use settings::RitaCommonSettings;
+use std::boxed::Box;
+use std::collections::HashMap;
+use std::net::{SocketAddr, TcpStream};
 
 #[derive(Serialize)]
 pub struct NodeInfo {

--- a/rita/src/rita_client/dashboard/notifications.rs
+++ b/rita/src/rita_client/dashboard/notifications.rs
@@ -1,4 +1,10 @@
-use super::*;
+use crate::ARGS;
+use crate::SETTING;
+use ::actix_web::Path;
+use ::actix_web::{HttpRequest, HttpResponse};
+use failure::Error;
+use settings::client::RitaClientSettings;
+use settings::FileWrite;
 
 pub fn get_low_balance_notification(_req: HttpRequest) -> Result<HttpResponse, Error> {
     let setting = SETTING.get_exit_client().low_balance_notification;

--- a/rita/src/rita_client/dashboard/system_chain.rs
+++ b/rita/src/rita_client/dashboard/system_chain.rs
@@ -1,6 +1,12 @@
-use super::*;
-
+use crate::ARGS;
+use crate::SETTING;
+use ::actix_web::http::StatusCode;
+use ::actix_web::Path;
+use ::actix_web::{HttpRequest, HttpResponse};
 use althea_types::SystemChain;
+use failure::Error;
+use settings::FileWrite;
+use settings::RitaCommonSettings;
 
 /// Changes the full node configuration value between test/prod and other networks
 pub fn set_system_blockchain(path: Path<String>) -> Result<HttpResponse, Error> {

--- a/rita/src/rita_client/dashboard/wifi.rs
+++ b/rita/src/rita_client/dashboard/wifi.rs
@@ -1,6 +1,14 @@
 //! These endpoints are used to modify mundane wireless settings
 
-use super::*;
+use crate::KI;
+use crate::SETTING;
+use ::actix_web::http::StatusCode;
+use ::actix_web::Path;
+use ::actix_web::{HttpRequest, HttpResponse, Json};
+use failure::Error;
+use serde_json::Value;
+use settings::RitaCommonSettings;
+use std::collections::HashMap;
 
 // legal in the US and around the world, don't allow odd channels
 pub const ALLOWED_TWO: [u16; 3] = [1, 6, 11];

--- a/rita/src/rita_common/dao_manager/mod.rs
+++ b/rita/src/rita_common/dao_manager/mod.rs
@@ -110,7 +110,7 @@ impl Handler<CacheCallback> for DAOManager {
         let dao_address = msg.dao_address;
         let response = msg.response;
         trace!("Got response {:?}", response);
-        let num: Uint256 = match response.result {
+        let _num: Uint256 = match response.result {
             Some(uint) => match uint.replace("0x", "").parse() {
                 Ok(parsed) => parsed,
                 Err(e) => {

--- a/rita/src/rita_common/dashboard/babel.rs
+++ b/rita/src/rita_common/dashboard/babel.rs
@@ -1,4 +1,14 @@
-use super::*;
+use crate::ARGS;
+use crate::SETTING;
+use ::actix_web::http::StatusCode;
+use ::actix_web::Path;
+use ::actix_web::{HttpRequest, HttpResponse, Result};
+use ::settings::FileWrite;
+use ::settings::RitaCommonSettings;
+use babel_monitor::Babel;
+use failure::Error;
+use std::collections::HashMap;
+use std::net::{SocketAddr, TcpStream};
 
 pub fn get_local_fee(_req: HttpRequest) -> Result<HttpResponse, Error> {
     debug!("/local_fee GET hit");

--- a/rita/src/rita_common/dashboard/dao.rs
+++ b/rita/src/rita_common/dashboard/dao.rs
@@ -1,4 +1,11 @@
-use super::*;
+use crate::ARGS;
+use crate::SETTING;
+use ::actix_web::Path;
+use ::actix_web::{HttpRequest, Json, Result};
+use ::settings::FileWrite;
+use ::settings::RitaCommonSettings;
+use clarity::Address;
+use failure::Error;
 
 pub fn get_dao_list(_req: HttpRequest) -> Result<Json<Vec<Address>>, Error> {
     trace!("get dao list: Hit");

--- a/rita/src/rita_common/dashboard/debts.rs
+++ b/rita/src/rita_common/dashboard/debts.rs
@@ -1,4 +1,10 @@
-use super::*;
+use crate::rita_common::debt_keeper::GetDebtsList;
+use crate::rita_common::debt_keeper::{DebtKeeper, GetDebtsResult};
+use ::actix::registry::SystemService;
+use ::actix_web::{AsyncResponder, HttpRequest, Json};
+use failure::Error;
+use futures::Future;
+use std::boxed::Box;
 
 pub fn get_debts(
     _req: HttpRequest,

--- a/rita/src/rita_common/dashboard/development.rs
+++ b/rita/src/rita_common/dashboard/development.rs
@@ -1,4 +1,5 @@
-use super::*;
+use ::actix_web::*;
+use failure::Error;
 
 #[cfg(not(feature = "development"))]
 pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {

--- a/rita/src/rita_common/dashboard/mod.rs
+++ b/rita/src/rita_common/dashboard/mod.rs
@@ -4,39 +4,6 @@
 
 use ::actix::prelude::*;
 use ::actix::registry::SystemService;
-use ::actix_web::http::StatusCode;
-use ::actix_web::Path;
-use ::actix_web::*;
-
-use failure::Error;
-
-use futures::{future, Future};
-
-use serde_json;
-
-use std::{
-    boxed::Box,
-    collections::HashMap,
-    net::{SocketAddr, TcpStream},
-};
-
-use arrayvec::ArrayString;
-
-use crate::SETTING;
-use ::settings::RitaCommonSettings;
-
-use babel_monitor::Babel;
-
-use clarity::{Address, Transaction};
-
-use web3::client::Web3;
-
-use crate::rita_common::debt_keeper::GetDebtsList;
-use crate::rita_common::debt_keeper::{DebtKeeper, GetDebtsResult};
-use crate::rita_common::network_endpoints::JsonStatusResponse;
-use crate::rita_common::rita_loop::get_web3_server;
-use crate::ARGS;
-use ::settings::FileWrite;
 
 pub mod babel;
 pub mod dao;

--- a/rita/src/rita_common/dashboard/nickname.rs
+++ b/rita/src/rita_common/dashboard/nickname.rs
@@ -1,4 +1,10 @@
-use super::*;
+use crate::ARGS;
+use crate::SETTING;
+use ::actix_web::{HttpRequest, HttpResponse, Json, Result};
+use ::settings::FileWrite;
+use ::settings::RitaCommonSettings;
+use arrayvec::ArrayString;
+use failure::Error;
 
 pub fn get_nickname(_req: HttpRequest) -> Result<HttpResponse, Error> {
     let nick = SETTING.get_network().nickname;

--- a/rita/src/rita_common/dashboard/own_info.rs
+++ b/rita/src/rita_common/dashboard/own_info.rs
@@ -1,5 +1,9 @@
-use super::*;
 use crate::rita_common::oracle::low_balance;
+use crate::SETTING;
+use ::settings::RitaCommonSettings;
+use actix_web::{HttpRequest, Json};
+use clarity::Address;
+use failure::Error;
 use num256::{Int256, Uint256};
 
 pub static READABLE_VERSION: &str = "Beta 3 RC5";

--- a/rita/src/rita_common/dashboard/pricing.rs
+++ b/rita/src/rita_common/dashboard/pricing.rs
@@ -1,4 +1,10 @@
-use super::*;
+use crate::ARGS;
+use crate::SETTING;
+use ::actix_web::Path;
+use ::actix_web::{HttpRequest, HttpResponse, Json, Result};
+use ::settings::FileWrite;
+use ::settings::RitaCommonSettings;
+use failure::Error;
 
 pub fn auto_pricing_status(_req: HttpRequest) -> Result<Json<bool>, Error> {
     debug!("Get Auto pricing enabled hit!");

--- a/rita/src/rita_common/dashboard/settings.rs
+++ b/rita/src/rita_common/dashboard/settings.rs
@@ -1,4 +1,9 @@
-use super::*;
+use crate::rita_common::network_endpoints::JsonStatusResponse;
+use crate::SETTING;
+use ::actix_web::*;
+use ::settings::RitaCommonSettings;
+use failure::Error;
+use serde_json;
 
 pub fn get_settings(_req: HttpRequest) -> Result<Json<serde_json::Value>, Error> {
     debug!("Get settings endpoint hit!");

--- a/rita/src/rita_common/dashboard/wallet.rs
+++ b/rita/src/rita_common/dashboard/wallet.rs
@@ -1,4 +1,14 @@
-use super::*;
+use crate::rita_common::rita_loop::get_web3_server;
+use crate::SETTING;
+use ::actix_web::http::StatusCode;
+use ::actix_web::HttpResponse;
+use ::actix_web::Path;
+use ::settings::RitaCommonSettings;
+use clarity::{Address, Transaction};
+use failure::Error;
+use futures::{future, Future};
+use std::boxed::Box;
+use web3::client::Web3;
 
 pub fn withdraw(path: Path<(Address, u64)>) -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
     let address = path.0;


### PR DESCRIPTION
This changes the way we import almost everything in both dashboard modules.
Rust would produce warnings for correct but somewhat complicated import
paths involving wildcards, this commit refactors how we import in those modules
to fix that.

There are also other warnings fixes for other modules.