### PR TITLE
Allow retrying for registration text messages

### DIFF
--- a/exit_db/migrations/2019-02-22-214628_rita-setup/up.sql
+++ b/exit_db/migrations/2019-02-22-214628_rita-setup/up.sql
@@ -7,12 +7,12 @@ CREATE TABLE clients
     internal_ip varchar(42) NOT NULL,
     nickname varchar(32) NOT NULL,
     email varchar(512) NOT NULL,
-    phone varchar(32)  NOT NULL,
+    phone varchar(32) NOT NULL,
     country varchar(8) NOT NULL,
     email_code varchar(16) NOT NULL,
     verified boolean DEFAULT FALSE NOT NULL,
     email_sent_time bigint DEFAULT 0 NOT NULL,
-    text_sent boolean DEFAULT FALSE NOT NULL,
+    text_sent integer DEFAULT FALSE NOT NULL,
     last_seen bigint DEFAULT 0 NOT NULL,
     last_balance_warning_time bigint DEFAULT 0 NOT NULL
 );

--- a/exit_db/src/models.rs
+++ b/exit_db/src/models.rs
@@ -15,7 +15,7 @@ pub struct Client {
     pub email_code: String,
     pub verified: bool,
     pub email_sent_time: i64,
-    pub text_sent: bool,
+    pub text_sent: i32,
     pub last_seen: i64,
     pub last_balance_warning_time: i64,
 }

--- a/exit_db/src/schema.rs
+++ b/exit_db/src/schema.rs
@@ -12,7 +12,7 @@ table! {
         email_code -> Varchar,
         verified -> Bool,
         email_sent_time -> Int8,
-        text_sent -> Bool,
+        text_sent -> Int4,
         last_seen -> Int8,
         last_balance_warning_time -> Int8,
     }

--- a/rita/src/rita_exit/database/database_tools.rs
+++ b/rita/src/rita_exit/database/database_tools.rs
@@ -117,12 +117,12 @@ pub fn verify_db_client(
     Ok(())
 }
 
-/// Marks a registration text as sent in the database
-pub fn text_sent(client: &ExitClientIdentity, conn: &PgConnection) -> Result<(), Error> {
+/// Increments the text message sent count in the database
+pub fn text_sent(client: &ExitClientIdentity, conn: &PgConnection, val: i32) -> Result<(), Error> {
     use self::schema::clients::dsl::*;
 
     diesel::update(clients.find(&client.global.mesh_ip.to_string()))
-        .set(text_sent.eq(true))
+        .set(text_sent.eq(val + 1))
         .execute(&*conn)?;
 
     Ok(())

--- a/rita/src/rita_exit/database/mod.rs
+++ b/rita/src/rita_exit/database/mod.rs
@@ -112,7 +112,7 @@ fn client_to_new_db_client(
         phone: client.reg_details.phone.clone().unwrap_or_default(),
         country,
         email_code: format!("{:06}", rand_code),
-        text_sent: false,
+        text_sent: 0,
         verified: false,
         email_sent_time: 0,
         last_seen: 0,
@@ -193,8 +193,7 @@ pub fn signup_client(client: ExitClientIdentity) -> Result<ExitState, Error> {
     }
 }
 
-/// Gets the status of a client and updates it in the database, not a member of
-/// DbClient because it needs to be called async
+/// Gets the status of a client and updates it in the database
 pub fn client_status(client: ExitClientIdentity) -> Result<ExitState, Error> {
     let conn = get_database_connection()?;
     let client_mesh_ip = client.global.mesh_ip;

--- a/rita/src/rita_exit/database/struct_tools.rs
+++ b/rita/src/rita_exit/database/struct_tools.rs
@@ -42,8 +42,9 @@ pub fn verif_done(client: &models::Client) -> bool {
     client.verified
 }
 
-/// returns true if text message has been sent
-pub fn text_done(client: &models::Client) -> bool {
+/// returns the number of text messages this entry has requested
+/// and recieved so far
+pub fn texts_sent(client: &models::Client) -> i32 {
     client.text_sent
 }
 


### PR DESCRIPTION
Text messages are a lot more lossy than email even, but we can't allow
text spam, this limits the number of text attempts people can make to 10