### PR TITLE
Automatic recovery for the main loops

### DIFF
--- a/rita/src/client.rs
+++ b/rita/src/client.rs
@@ -46,7 +46,6 @@ use settings::client::{RitaClientSettings, RitaSettingsStruct};
 use settings::RitaCommonSettings;
 
 use actix::registry::SystemService;
-use actix::*;
 use actix_web::http::Method;
 use actix_web::{http, server, App};
 
@@ -313,6 +312,7 @@ fn main() {
                 set_low_balance_notification,
             )
             .route("/wipe", Method::POST, wipe)
+            .route("/crash_actors", Method::POST, crash_actors)
     })
     .workers(1)
     .bind(format!(
@@ -323,11 +323,8 @@ fn main() {
     .shutdown_timeout(0)
     .start();
 
-    let common = rita_common::rita_loop::RitaLoop::new();
-    let _: Addr<_> = common.start();
-
-    let client = rita_client::rita_loop::RitaLoop {};
-    let _: Addr<_> = client.start();
+    assert!(rita_common::rita_loop::RitaLoop::from_registry().connected());
+    assert!(rita_client::rita_loop::RitaLoop::from_registry().connected());
 
     system.run();
 }

--- a/rita/src/exit.rs
+++ b/rita/src/exit.rs
@@ -48,7 +48,6 @@ use docopt::Docopt;
 use settings::FileWrite;
 
 use actix::registry::SystemService;
-use actix::*;
 use actix_web::http::Method;
 use actix_web::{http, server, App};
 
@@ -70,7 +69,6 @@ use crate::rita_common::dashboard::wallet::*;
 use crate::rita_common::network_endpoints::*;
 use crate::rita_exit::network_endpoints::*;
 
-use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 #[cfg(test)]
@@ -274,6 +272,7 @@ fn main() {
             .route("/auto_price/enabled", Method::GET, auto_pricing_status)
             .route("/nickname/get/", Method::GET, get_nickname)
             .route("/nickname/set/", Method::POST, set_nickname)
+            .route("/crash_actors", Method::POST, crash_actors)
     })
     .bind(format!(
         "[::0]:{}",
@@ -283,13 +282,8 @@ fn main() {
     .shutdown_timeout(0)
     .start();
 
-    let common = rita_common::rita_loop::RitaLoop::new();
-    let _: Addr<_> = common.start();
-
-    let exit = rita_exit::rita_loop::RitaLoop {
-        geoip_cache: HashMap::new(),
-    };
-    let _: Addr<_> = exit.start();
+    assert!(rita_common::rita_loop::RitaLoop::from_registry().connected());
+    assert!(rita_exit::rita_loop::RitaLoop::from_registry().connected());
 
     system.run();
 }

--- a/rita/src/rita_client/exit_manager/mod.rs
+++ b/rita/src/rita_client/exit_manager/mod.rs
@@ -296,22 +296,20 @@ fn exit_status_request(exit: String) -> impl Future<Item = (), Error = Error> {
         endpoint
     );
 
-    let r = send_exit_status_request(&endpoint, ident)
-        .from_err()
-        .and_then(move |exit_response| {
-            let mut exits = SETTING.get_exits_mut();
+    let r = send_exit_status_request(&endpoint, ident).and_then(move |exit_response| {
+        let mut exits = SETTING.get_exits_mut();
 
-            let current_exit = match exits.get_mut(&exit) {
-                Some(exit_struct) => exit_struct,
-                None => bail!("Could not find exit {:?}", exit),
-            };
+        let current_exit = match exits.get_mut(&exit) {
+            Some(exit_struct) => exit_struct,
+            None => bail!("Could not find exit {:?}", exit),
+        };
 
-            current_exit.info = exit_response.clone();
+        current_exit.info = exit_response.clone();
 
-            trace!("Got exit status response {:?}", exit_response.clone());
+        trace!("Got exit status response {:?}", exit_response.clone());
 
-            Ok(())
-        });
+        Ok(())
+    });
     Box::new(r)
 }
 

--- a/rita/src/rita_common/dashboard/development.rs
+++ b/rita/src/rita_common/dashboard/development.rs
@@ -1,5 +1,33 @@
-use ::actix_web::{HttpRequest, HttpResponse, Result};
+#[cfg(feature = "development")]
+use crate::rita_common::rita_loop::Crash;
+#[cfg(feature = "development")]
+use crate::rita_common::rita_loop::RitaLoop as RitaCommonLoop;
+#[cfg(feature = "development")]
+use crate::KI;
+#[cfg(feature = "development")]
+use crate::SETTING;
+#[cfg(feature = "development")]
+use actix::registry::SystemService;
+use actix_web::{HttpRequest, HttpResponse, Result};
+#[cfg(feature = "development")]
+use clu::{cleanup, linux_generate_mesh_ip};
 use failure::Error;
+#[cfg(feature = "development")]
+use settings::RitaCommonSettings;
+#[cfg(feature = "development")]
+use std::path::Path;
+
+#[cfg(not(feature = "development"))]
+pub fn crash_actors(_req: HttpRequest) -> Result<HttpResponse, Error> {
+    // This is returned on production builds.
+    Ok(HttpResponse::NotFound().finish())
+}
+
+#[cfg(feature = "development")]
+pub fn crash_actors(_req: HttpRequest) -> Result<HttpResponse, Error> {
+    RitaCommonLoop::from_registry().do_send(Crash {});
+    Ok(HttpResponse::Ok().json(()))
+}
 
 #[cfg(not(feature = "development"))]
 pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
@@ -9,6 +37,8 @@ pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
 
 #[cfg(feature = "development")]
 pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
+    let mut network_settings = SETTING.get_network_mut();
+
     // Clean up existing WG interfaces
     match cleanup() {
         Ok(_) => trace!("wipe: WireGuard interfaces cleanup success!"),
@@ -22,7 +52,7 @@ pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
     }
 
     // Restore default route
-    match KI.restore_default_route(&mut SETTING.get_network_mut().default_route) {
+    match KI.restore_default_route(&mut network_settings.default_route) {
         Ok(_) => trace!("wipe: Restore default route success!"),
         Err(e) => {
             warn!("wipe: Unable to restore default route: {:?}", e);
@@ -31,16 +61,16 @@ pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
     }
 
     // Create new WireGuard keys
-    match linux_generate_wg_keys(&mut SETTING.get_network_mut()) {
-        Ok(_) => trace!("wipe: Generated new WireGuard keys"),
-        Err(e) => {
-            warn!("wipe: Unable to generate new WireGuard keys: {:?}", e);
-            return Err(e);
-        }
-    }
+    let keypair = KI.create_wg_keypair().expect("failed to generate wg keys");
+    network_settings.wg_public_key = Some(keypair.public);
+    network_settings.wg_private_key = Some(keypair.private);
+
     // Generate new mesh IP
-    match linux_generate_mesh_ip(&mut SETTING.get_network_mut()) {
-        Ok(_) => trace!("wipe: Generated new mesh IP"),
+    match linux_generate_mesh_ip() {
+        Ok(ip) => {
+            trace!("wipe: Generated new mesh IP");
+            network_settings.mesh_ip = Some(ip);
+        }
         Err(e) => {
             warn!("wipe: Unable to generate new mesh IP: {:?}", e);
             return Err(e);
@@ -49,8 +79,8 @@ pub fn wipe(_req: HttpRequest) -> Result<HttpResponse, Error> {
 
     // Creates file on disk containing key
     match KI.create_wg_key(
-        &Path::new(&SETTING.get_network().wg_private_key_path),
-        &SETTING.get_network().wg_private_key,
+        &Path::new(&network_settings.wg_private_key_path),
+        &network_settings.wg_private_key.unwrap(),
     ) {
         Ok(_) => trace!("wipe: Saved new WireGuard keys to disk"),
         Err(e) => {

--- a/rita/src/rita_exit/network_endpoints/mod.rs
+++ b/rita/src/rita_exit/network_endpoints/mod.rs
@@ -1,6 +1,17 @@
 //! Network endpoints for rita-exit that are not dashboard or local infromational endpoints
 //! these are called by rita instances to operate the mesh
 
+#[cfg(feature = "development")]
+use crate::rita_exit::database::db_client::DbClient;
+#[cfg(feature = "development")]
+use crate::rita_exit::database::db_client::TruncateTables;
+#[cfg(feature = "development")]
+use actix::SystemService;
+#[cfg(feature = "development")]
+use actix_web::AsyncResponder;
+#[cfg(feature = "development")]
+use futures::Future;
+
 use ::actix_web::{HttpRequest, HttpResponse, Json, Result};
 
 use crate::rita_exit::database::{client_status, get_exit_info, signup_client};


### PR DESCRIPTION
We have some crashes that are very hard to reproduce, only happening once in
20 or so power on months. Hopefully by moving the main loops to system services
we can ensure that things always come back online correctly.