### PR TITLE
Seperate common and exit tunnel keys

### DIFF
--- a/rita/src/exit.rs
+++ b/rita/src/exit.rs
@@ -147,7 +147,7 @@ lazy_static! {
 #[cfg(test)]
 lazy_static! {
     pub static ref SETTING: Arc<RwLock<RitaExitSettingsStruct>> =
-        { Arc::new(RwLock::new(RitaExitSettingsStruct::default())) };
+        { Arc::new(RwLock::new(RitaExitSettingsStruct::test_default())) };
 }
 
 /// used to crash the exit on first startup if config does not make sense

--- a/rita/src/rita_exit/database/mod.rs
+++ b/rita/src/rita_exit/database/mod.rs
@@ -438,7 +438,7 @@ pub fn setup_clients(clients_list: &[exit_db::models::Client]) -> Result<(), Err
     let exit_status = KI.set_exit_wg_config(
         wg_clients,
         SETTING.get_exit_network().wg_tunnel_port,
-        &SETTING.get_network().wg_private_key_path,
+        &SETTING.get_exit_network().wg_private_key_path,
         &SETTING.get_exit_network().own_internal_ip.into(),
         SETTING.get_exit_network().netmask,
     );

--- a/settings/default_exit.toml
+++ b/settings/default_exit.toml
@@ -18,8 +18,8 @@ rita_contact_port = 4874
 rita_dashboard_port = 4877
 rita_tick_interval = 5
 bounty_port = 8888
-wg_public_key = "H/ABwzXk834OwGYU8CZGfFxNZOd+BAJEaVDHiEiWWhU="
-wg_private_key = "ALxcZm2r58gY0sB4vIfnjShc86qBoVK3f32H9VrwqWU="
+wg_public_key = "bvM10HW73yePrxdtCQQ4U20W5ogogdiZtUihrPc/oGY="
+wg_private_key = "OGzbcm6czrjOEAViK7ZzlWM8mtjCxp7UPbuLS/dATV4="
 wg_private_key_path = "/tmp/priv"
 wg_start_port = 60000
 peer_interfaces = []
@@ -36,6 +36,9 @@ own_internal_ip = "172.168.1.254"
 exit_start_ip = "172.168.1.100"
 netmask = 24
 entry_timeout = 7776000
+wg_public_key = "H/ABwzXk834OwGYU8CZGfFxNZOd+BAJEaVDHiEiWWhU="
+wg_private_key = "ALxcZm2r58gY0sB4vIfnjShc86qBoVK3f32H9VrwqWU="
+wg_private_key_path = "/tmp/exit-priv"
 
 [dao]
 dao_enforcement = false
@@ -43,7 +46,10 @@ cache_timeout_seconds = 600
 node_list = []
 dao_addresses = []
 
-[mailer]
+[verif_settings]
+type = "Email"
+
+[verif_settings.contents]
 test = true
 email_cooldown=60
 test_dir = "mail"

--- a/settings/example_exit.toml
+++ b/settings/example_exit.toml
@@ -17,9 +17,9 @@ rita_contact_port = 4874
 rita_dashboard_port = 4877
 rita_tick_interval = 5
 bounty_port = 8888
+wg_public_key = "bvM10HW73yePrxdtCQQ4U20W5ogogdiZtUihrPc/oGY="
+wg_private_key = "OGzbcm6czrjOEAViK7ZzlWM8mtjCxp7UPbuLS/dATV4="
 wg_private_key_path = "/tmp/priv"
-wg_public_key = "H/ABwzXk834OwGYU8CZGfFxNZOd+BAJEaVDHiEiWWhU="
-wg_private_key = "ALxcZm2r58gY0sB4vIfnjShc86qBoVK3f32H9VrwqWU="
 wg_start_port = 60000
 tunnel_timeout_seconds = 900
 peer_interfaces = []
@@ -41,8 +41,14 @@ own_internal_ip = "172.168.1.254"
 exit_start_ip = "172.168.1.100"
 netmask = 24
 entry_timeout = 7776000
+wg_public_key = "H/ABwzXk834OwGYU8CZGfFxNZOd+BAJEaVDHiEiWWhU="
+wg_private_key = "ALxcZm2r58gY0sB4vIfnjShc86qBoVK3f32H9VrwqWU="
+wg_private_key_path = "/tmp/exit-priv"
 
-[mailer]
+[verif_settings]
+type = "Email"
+
+[verif_settings.contents]
 email_cooldown=60
 from_address = "verification@example.com"
 smtp_url = "smtp.fastmail.com"
@@ -50,6 +56,7 @@ smtp_domain = "mail.example.com"
 smtp_username = "changeme"
 smtp_password = "changeme"
 balance_notification_interval = 600
+
 
 [log]
 enabled = false


### PR DESCRIPTION
This seperates the Rita exit per hop tunnel key from the exit tunnel keys,
the main reason for this is that multihomed exits don't play well with multiple
per hop tunnel potentially using the same key. For the exit tunnel this is fine, because
babel makes sure that the multihomed ip routes properly even as the network changes, for
gateways this can end very badly. Two exits using the same per hop tunnel key will both send
valid handshakes to the same client, causing them to switch between destinations in a sort of
flapping behavior based on the last valid handshake source.