### PR TITLE
Quantum must be specified on the root HTB qdisc not the class

### DIFF
--- a/althea_kernel_interface/src/lib.rs
+++ b/althea_kernel_interface/src/lib.rs
@@ -90,6 +90,15 @@ pub trait CommandRunner {
     fn set_mock(&self, mock: Box<dyn FnMut(String, Vec<String>) -> Result<Output, Error> + Send>);
 }
 
+// a quick throwaway function to print arguments arrays so that they can be copy/pasted from logs
+fn print_str_array(input: &[&str]) -> String {
+    let mut output = String::new();
+    for item in input {
+        output = output + " " + item;
+    }
+    output
+}
+
 pub struct LinuxCommandRunner;
 
 impl CommandRunner for LinuxCommandRunner {
@@ -105,12 +114,17 @@ impl CommandRunner for LinuxCommandRunner {
             }
         };
 
-        trace!("Command {:?} {:?} returned: {:?}", program, args, output);
+        trace!(
+            "Command {} {} returned: {:?}",
+            program,
+            print_str_array(args),
+            output
+        );
         if !output.status.success() {
             trace!(
-                "Command {:?} {:?} returned: an error {:?}",
+                "Command {} {} returned: an error {:?}",
                 program,
-                args,
+                print_str_array(args),
                 output
             );
         }

--- a/althea_kernel_interface/src/traffic_control.rs
+++ b/althea_kernel_interface/src/traffic_control.rs
@@ -207,10 +207,11 @@ impl KernelInterface {
                 &format!("{}kbit", min_bw),
                 "ceil",
                 &format!("{}kbit", max_bw),
-                // packet size plus 14 header bytes
-                "quantum 1354",
-                // 50 packets based on the above packet size
-                "burst 67700",
+                // 50 packets as mtu plus 14 bytes
+                "burst",
+                "70K",
+                "quantum",
+                "1354",
             ],
         )?;
 

--- a/rita/src/rita_exit/database/mod.rs
+++ b/rita/src/rita_exit/database/mod.rs
@@ -502,7 +502,7 @@ pub fn enforce_exit_clients(
                                             KI.set_class_limit("wg_exit", 100_000, 1_000_000, &ip)
                                         };
                                         if res.is_err() {
-                                            warn!("Failed to limit {} with {:?}", ip, res);
+                                            panic!("Failed to limit {} with {:?}", ip, res);
                                         }
                                     }
                                     _ => warn!("Can't parse Ipv4Addr to create limit!"),


### PR DESCRIPTION
This is a pretty major screw up, the class command contained
the quantum argument, which it does not allow, so all class setting
was failed and simply taken as an acceptible error.

This commit now panics on failure to create a class, since it should
work in the abscense of a logic or critical system error