### PR TITLE
WifiSettings combined endpoint

### DIFF
--- a/docs/api/router-dashboard.md
+++ b/docs/api/router-dashboard.md
@@ -484,6 +484,9 @@ application/json" -d '\{"url": "https://somewhere.safe"\}'
 
 ## /wifi_settings
 
+Takes a list of objects that are the same as the /ssid /pass and /channel endpoints
+they need to be tagged WifiChannel, WifiPass, and WifiSSID as shown below
+
 - URL: `<rita ip>:<rita_dashboard_port>/wifi_settings`
 - Method: `POST`
 - URL Params: `Content-Type: application/json`
@@ -498,7 +501,7 @@ application/json" -d '\{"url": "https://somewhere.safe"\}'
 
 - Error Response: `500 Server Error`
 - Sample Call:
-  `curl -XPOST 127.0.0.1:<rita_dashboard_port>/settings -H 'Content-Type: application/json' -i -d '{"default_radio0": {"ssid": "NetworkName"}}'`
+  `curl -XPOST 127.0.0.1:<rita_dashboard_port>/settings -H 'Content-Type: application/json' -i -d '[{"WifiChannel": {"radio":"radio0", "ssid": "this is a freeform ssid"}}, {"WifiChannel":{"radio":"radio1", "channel": 34}}]'`
 
 ---
 

--- a/rita/src/client.rs
+++ b/rita/src/client.rs
@@ -277,6 +277,7 @@ fn main() {
             .route("/settings", Method::GET, get_settings)
             .route("/settings", Method::POST, set_settings)
             .route("/version", Method::GET, version)
+            .route("/wifi_settings", Method::POST, set_wifi_multi)
             .route("/wifi_settings/pass", Method::POST, set_wifi_pass)
             .route("/wifi_settings/ssid", Method::POST, set_wifi_ssid)
             .route("/wifi_settings/channel", Method::POST, set_wifi_channel)


### PR DESCRIPTION
Most users try and change the wifi settings while on wifi themselves
this causes a bunch of problems when they attempt to change several
settings at different endpoints but their connection is disrupted by
each individual change.

From the users perspective only some changes get applied when they
hit save.

This commit updates the /wifi_settings endpoint to interpret the
same json objects previously posted to individual endpoints as an array
of tokens all of which are iterated over and applied as one operation