### PR TITLE
Tune Babel rtt-max to 40ms

### DIFF
--- a/babel_monitor/src/lib.rs
+++ b/babel_monitor/src/lib.rs
@@ -172,7 +172,7 @@ impl<T: Read + Write> Babel<T> {
 
     pub fn monitor(&mut self, iface: &str) -> Result<(), Error> {
         let _ = self.command(&format!(
-            "interface {} max-rtt-penalty 500 enable-timestamps true",
+            "interface {} max-rtt-penalty 500 enable-timestamps true rtt-max 60",
             iface
         ))?;
         trace!("Babel started monitoring: {}", iface);


### PR DESCRIPTION
While most tunnels will be over point to point wireless gear some
will be over long distance tunnels to exits, for those longer distance
tunnels latency may invert often. In this case we want to select the
lower latency route without flapping uselessly between longer distance
ones.