### PR TITLE
Babel does not allow uintmax for local fees

### DIFF
--- a/rita/src/rita_common/dashboard/babel.rs
+++ b/rita/src/rita_common/dashboard/babel.rs
@@ -31,6 +31,11 @@ pub fn set_local_fee(path: Path<u32>) -> Result<HttpResponse, Error> {
     debug!("/local_fee/{} POST hit", new_fee);
     let mut ret = HashMap::<String, String>::new();
 
+    if new_fee > 999_999_999 {
+        // required because of https://github.com/althea-mesh/babeld/issues/28
+        bail!("Price is too high due to babel bug!");
+    }
+
     let stream = match TcpStream::connect::<SocketAddr>(
         format!("[::1]:{}", SETTING.get_network().babel_port)
             .parse()

--- a/rita/src/rita_common/traffic_watcher/mod.rs
+++ b/rita/src/rita_common/traffic_watcher/mod.rs
@@ -103,7 +103,15 @@ pub fn get_babel_info<T: Read + Write>(
     let routes = babel.parse_routes()?;
     trace!("Got routes: {:?}", routes);
     let mut destinations = HashMap::new();
-    let local_fee = babel.get_local_fee().unwrap();
+    let local_fee = match babel.get_local_fee() {
+        Ok(fee) => fee,
+        Err(e) => {
+            error!("Babel fee not set properly! this is a bad sign! {:?}", e);
+            let configured_fee = SETTING.get_payment().local_fee;
+            babel.set_local_fee(configured_fee)?;
+            configured_fee
+        }
+    };
 
     let max_fee = SETTING.get_payment().max_fee;
     for route in &routes {

--- a/rita/src/rita_exit/traffic_watcher/mod.rs
+++ b/rita/src/rita_exit/traffic_watcher/mod.rs
@@ -84,12 +84,19 @@ fn get_babel_info<T: Read + Write>(
     let routes = babel.parse_routes()?;
     info!("Got routes: {:?}", routes);
 
+    let local_fee = match babel.get_local_fee() {
+        Ok(fee) => fee,
+        Err(e) => {
+            error!("Babel fee not set properly! this is a bad sign! {:?}", e);
+            let configured_fee = SETTING.get_payment().local_fee;
+            babel.set_local_fee(configured_fee)?;
+            configured_fee
+        }
+    };
+
     // insert ourselves as a destination, don't think this is actually needed
     let mut destinations = HashMap::new();
-    destinations.insert(
-        our_id.wg_public_key,
-        u64::from(babel.get_local_fee().unwrap()),
-    );
+    destinations.insert(our_id.wg_public_key, u64::from(local_fee));
 
     let max_fee = SETTING.get_payment().max_fee;
     for route in &routes {


### PR DESCRIPTION
This adds some recovery code for this error case as well as prevents
a fee that high from being set in the first place