### PR TITLE
Add fee multiplier to the oracle

### DIFF
--- a/rita/src/rita_common/oracle/mod.rs
+++ b/rita/src/rita_common/oracle/mod.rs
@@ -207,13 +207,10 @@ fn update_gas_price(web3: &Web3) {
                 let mut payment_settings = SETTING.get_payment_mut();
 
                 if payment_settings.system_chain == SystemChain::Xdai {
-                    payment_settings.pay_threshold = 105_000_000_000_000_000u128.into();
-                    payment_settings.close_threshold = (420_000_000_000_000_000i128 * -1).into();
                     payment_settings.gas_price = 250_000_000_000u128.into();
-                    return Ok(());
+                } else {
+                    payment_settings.gas_price = value;
                 }
-
-                payment_settings.gas_price = value;
                 let dynamic_fee_factor: Int256 = payment_settings.dynamic_fee_multiplier.into();
                 let transaction_gas: Int256 = 21000.into();
                 let neg_one = -1i32;
@@ -259,6 +256,7 @@ struct PriceUpdate {
     max: u32,
     dao_fee: u32,
     warning: u128,
+    fee_multiplier: u32,
 }
 
 /// This is a very simple and early version of an automated pricing system
@@ -303,7 +301,8 @@ fn update_our_price() {
                                             payment.max_fee = new_prices.max;
                                             payment.balance_warning_level =
                                                 new_prices.warning.into();
-
+                                            payment.dynamic_fee_multiplier =
+                                                new_prices.fee_multiplier;
                                             drop(payment);
 
                                             let mut dao = SETTING.get_dao_mut();


### PR DESCRIPTION
During testing today I realized that the fee multiplier held implicit
info about the price, if the transaction fee value versus the fee multiplier
versus the amount of bandwidth being sold is off then it's possible to blow
through the grace period in less time than it may take for a block to be produced
on chain.

Making any one of these factors tunable is pretty equal so I chose the fee multiplier.
This should make it easy for us to keep the price to fee multiplier ratio reasonable.