### PR TITLE
Add timeouts to babel tcpstream operations

### DIFF
--- a/rita/src/rita_client/dashboard/exits.rs
+++ b/rita/src/rita_client/dashboard/exits.rs
@@ -11,6 +11,7 @@ use ::actix_web::AsyncResponder;
 use ::actix_web::Path;
 use ::actix_web::{HttpRequest, HttpResponse, Json};
 use althea_types::ExitState;
+use babel_monitor::open_babel_stream;
 use babel_monitor::Babel;
 use failure::Error;
 use futures::{future, Future};
@@ -20,7 +21,6 @@ use settings::FileWrite;
 use settings::RitaCommonSettings;
 use std::boxed::Box;
 use std::collections::HashMap;
-use std::net::{SocketAddr, TcpStream};
 use std::time::Duration;
 
 #[derive(Serialize)]
@@ -66,9 +66,7 @@ impl Handler<GetExitInfo> for Dashboard {
     type Result = Result<Vec<ExitInfo>, Error>;
 
     fn handle(&mut self, _msg: GetExitInfo, _ctx: &mut Self::Context) -> Self::Result {
-        let stream = TcpStream::connect::<SocketAddr>(
-            format!("[::1]:{}", SETTING.get_network().babel_port).parse()?,
-        )?;
+        let stream = open_babel_stream(SETTING.get_network().babel_port)?;
         let mut babel = Babel::new(stream);
         babel.start_connection()?;
         let route_table_sample = babel.parse_routes()?;

--- a/rita/src/rita_client/traffic_watcher/mod.rs
+++ b/rita/src/rita_client/traffic_watcher/mod.rs
@@ -14,17 +14,16 @@ use crate::KI;
 use crate::SETTING;
 use ::actix::prelude::{Actor, Context, Handler, Message, Supervised, SystemService};
 use althea_types::Identity;
+use babel_monitor::open_babel_stream;
 use babel_monitor::Babel;
 use babel_monitor::Route;
 use failure::Error;
 use settings::RitaCommonSettings;
-use std::net::{IpAddr, SocketAddr, TcpStream};
+use std::net::IpAddr;
 
 /// Returns the babel route to a given mesh ip with the properly capped price
 fn find_exit_route_capped(exit_mesh_ip: IpAddr) -> Result<Route, Error> {
-    let stream = TcpStream::connect::<SocketAddr>(
-        format!("[::1]:{}", SETTING.get_network().babel_port).parse()?,
-    )?;
+    let stream = open_babel_stream(SETTING.get_network().babel_port)?;
     let mut babel = Babel::new(stream);
 
     babel.start_connection()?;

--- a/rita/src/rita_common/dashboard/babel.rs
+++ b/rita/src/rita_common/dashboard/babel.rs
@@ -5,10 +5,10 @@ use ::actix_web::Path;
 use ::actix_web::{HttpRequest, HttpResponse, Result};
 use ::settings::FileWrite;
 use ::settings::RitaCommonSettings;
+use babel_monitor::open_babel_stream;
 use babel_monitor::Babel;
 use failure::Error;
 use std::collections::HashMap;
-use std::net::{SocketAddr, TcpStream};
 
 pub fn get_local_fee(_req: HttpRequest) -> Result<HttpResponse, Error> {
     debug!("/local_fee GET hit");
@@ -36,11 +36,7 @@ pub fn set_local_fee(path: Path<u32>) -> Result<HttpResponse, Error> {
         bail!("Price is too high due to babel bug!");
     }
 
-    let stream = match TcpStream::connect::<SocketAddr>(
-        format!("[::1]:{}", SETTING.get_network().babel_port)
-            .parse()
-            .unwrap(),
-    ) {
+    let stream = match open_babel_stream(SETTING.get_network().babel_port) {
         Ok(s) => s,
         Err(e) => {
             error!("Failed to set local fee! {:?}", e);
@@ -102,11 +98,7 @@ pub fn set_metric_factor(path: Path<u32>) -> Result<HttpResponse, Error> {
     debug!("/metric_factor/{} POST hit", new_factor);
     let mut ret = HashMap::<String, String>::new();
 
-    let stream = match TcpStream::connect::<SocketAddr>(
-        format!("[::1]:{}", SETTING.get_network().babel_port)
-            .parse()
-            .unwrap(),
-    ) {
+    let stream = match open_babel_stream(SETTING.get_network().babel_port) {
         Ok(s) => s,
         Err(e) => {
             error!("Failed to set metric factor! {:?}", e);

--- a/rita/src/rita_common/tunnel_manager/mod.rs
+++ b/rita/src/rita_common/tunnel_manager/mod.rs
@@ -15,6 +15,7 @@ use ::actix::actors::resolver;
 use ::actix::prelude::{Actor, Arbiter, Context, Handler, Message, Supervised, SystemService};
 use althea_types::Identity;
 use althea_types::LocalIdentity;
+use babel_monitor::open_babel_stream;
 use babel_monitor::Babel;
 use failure::Error;
 use futures::Future;
@@ -281,9 +282,8 @@ impl Handler<PortCallback> for TunnelManager {
 }
 
 pub fn make_babel_stream() -> Result<TcpStream, Error> {
-    let stream = TcpStream::connect::<SocketAddr>(
-        format!("[::1]:{}", SETTING.get_network().babel_port).parse()?,
-    )?;
+    let stream = open_babel_stream(SETTING.get_network().babel_port)?;
+
     Ok(stream)
 }
 


### PR DESCRIPTION
I've seen babel hang some in production, this adds a pretty reasonable
timeout to Babel read/write operations