### PR TITLE
Improve PaymentValidator to be resistant to txid replay attacks

### DIFF
--- a/rita/src/rita_common/payment_validator/mod.rs
+++ b/rita/src/rita_common/payment_validator/mod.rs
@@ -30,6 +30,8 @@ use web3::types::TransactionResponse;
 pub const PAYMENT_TIMEOUT: Duration = Duration::from_secs(900u64);
 // How many blocks before we assume finality
 const BLOCKS_TO_CONFIRM: u32 = 4;
+// How old does a txid need to be before we don't accept it?
+const BLOCKS_TO_OLD: u32 = 1440;
 
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]
 pub struct ToValidate {
@@ -39,6 +41,7 @@ pub struct ToValidate {
 
 pub struct PaymentValidator {
     unvalidated_transactions: HashSet<ToValidate>,
+    successful_transactions: HashSet<Uint256>,
 }
 
 impl Actor for PaymentValidator {
@@ -56,6 +59,7 @@ impl PaymentValidator {
     pub fn new() -> Self {
         PaymentValidator {
             unvalidated_transactions: HashSet::new(),
+            successful_transactions: HashSet::new(),
         }
     }
 }
@@ -66,6 +70,12 @@ impl Default for PaymentValidator {
     }
 }
 
+/// Message to insert transactions into payment validator, once inserted they will remain
+/// until they are validated, dropped for validity issues, or time out without being inserted
+/// into the blockchain. Transactions that are too old are prevented from being played back
+/// by using a history of successful transactions.
+/// This endpoint specifically (and only this one) is fully imdepotent so that we can retry
+/// txid transmissions
 #[derive(Message)]
 pub struct ValidateLater(pub ToValidate);
 
@@ -73,18 +83,38 @@ impl Handler<ValidateLater> for PaymentValidator {
     type Result = ();
 
     fn handle(&mut self, msg: ValidateLater, _ctx: &mut Context<Self>) -> Self::Result {
-        self.unvalidated_transactions.insert(msg.0);
+        let ts = msg.0;
+        if let Some(txid) = ts.payment.txid.clone() {
+            if !self.successful_transactions.contains(&txid) {
+                // insert is safe to run multiple times just so long as we check successful tx's for duplicates
+                self.unvalidated_transactions.insert(ts);
+            }
+        } else {
+            error!(
+                "Someone tried to insert an unpublished transaction to validate!? {:?}",
+                ts
+            );
+        }
     }
 }
 
 #[derive(Message)]
-pub struct Remove(pub ToValidate);
+pub struct Remove {
+    tx: ToValidate,
+    success: bool,
+}
 
 impl Handler<Remove> for PaymentValidator {
     type Result = ();
 
     fn handle(&mut self, msg: Remove, _ctx: &mut Context<Self>) -> Self::Result {
-        self.unvalidated_transactions.remove(&msg.0);
+        self.unvalidated_transactions.remove(&msg.tx);
+        // store successful transactions so that they can't be played back to us, at least
+        // during this session
+        if msg.success {
+            self.successful_transactions
+                .insert(msg.tx.payment.txid.unwrap());
+        }
     }
 }
 
@@ -174,11 +204,30 @@ fn handle_tx_messaging(
     let to_us = transaction.to == our_address;
     let from_us = transaction.from == our_address;
     let value_correct = transaction.value == amount;
-    let is_in_chain = payment_in_chain(current_block, transaction.block_number);
+    let is_in_chain = payment_in_chain(current_block.clone(), transaction.block_number.clone());
+    let is_old = payment_is_old(current_block, transaction.block_number);
 
-    match (to_us, from_us, value_correct, is_in_chain) {
+    if !value_correct {
+        error!("Transaction with invalid amount!");
+        PaymentValidator::from_registry().do_send(Remove {
+            tx: ts,
+            success: false,
+        });
+        return;
+    }
+
+    if is_old {
+        error!("Transaction is more than 6 hours old! {:?}", pmt.txid);
+        PaymentValidator::from_registry().do_send(Remove {
+            tx: ts,
+            success: false,
+        });
+        return;
+    }
+
+    match (to_us, from_us, is_in_chain) {
         // we where successfully paid
-        (true, false, true, true) => {
+        (true, false, true) => {
             info!(
                 "payment {:#066x}  from {} successfully validated!",
                 txid, from_address
@@ -187,13 +236,16 @@ fn handle_tx_messaging(
                 from: pmt.from,
                 amount: pmt.amount.clone(),
             });
-            PaymentValidator::from_registry().do_send(Remove(ts));
+            PaymentValidator::from_registry().do_send(Remove {
+                tx: ts,
+                success: true,
+            });
 
             // update the usage tracker with the details of this payment
             UsageTracker::from_registry().do_send(UpdatePayments { payment: pmt });
         }
         // we suceessfully paid someone
-        (false, true, true, true) => {
+        (false, true, true) => {
             info!(
                 "payment {:#066x}  from {} successfully sent!",
                 txid, from_address
@@ -202,28 +254,29 @@ fn handle_tx_messaging(
                 to: pmt.to,
                 amount: pmt.amount.clone(),
             });
-            PaymentValidator::from_registry().do_send(Remove(ts));
+            PaymentValidator::from_registry().do_send(Remove {
+                tx: ts,
+                success: true,
+            });
 
             // update the usage tracker with the details of this payment
             UsageTracker::from_registry().do_send(UpdatePayments { payment: pmt });
         }
-        (true, false, false, _) => {
-            error!("Transaction with invalid amount!");
-            PaymentValidator::from_registry().do_send(Remove(ts));
-        }
-        (false, true, false, _) => {
-            error!("Transaction with invalid amount!");
-            PaymentValidator::from_registry().do_send(Remove(ts));
-        }
-        (true, true, _, _) => {
+        (true, true, _) => {
             error!("Transaction to ourselves!");
-            PaymentValidator::from_registry().do_send(Remove(ts));
+            PaymentValidator::from_registry().do_send(Remove {
+                tx: ts,
+                success: false,
+            });
         }
-        (false, false, _, _) => {
+        (false, false, _) => {
             error!("Transaction has nothing to do with us?");
-            PaymentValidator::from_registry().do_send(Remove(ts));
+            PaymentValidator::from_registry().do_send(Remove {
+                tx: ts,
+                success: false,
+            });
         }
-        (_, _, _, false) => {
+        (_, _, false) => {
             //transaction waiting for validation, do nothing
         }
     }
@@ -238,6 +291,21 @@ fn payment_in_chain(chain_height: Uint256, tx_height: Option<Uint256>) -> bool {
                 false
             } else {
                 chain_height - tx_block >= Uint256::from(BLOCKS_TO_CONFIRM)
+            }
+        }
+        None => false,
+    }
+}
+
+/// Determine if a given payment is older than what we shoul accept
+fn payment_is_old(chain_height: Uint256, tx_height: Option<Uint256>) -> bool {
+    match tx_height {
+        Some(tx_block) => {
+            // somehow the block is newer than our block height request, wait until later
+            if tx_block > chain_height {
+                false
+            } else {
+                chain_height - tx_block < Uint256::from(BLOCKS_TO_OLD)
             }
         }
         None => false,


### PR DESCRIPTION
Previously PaymentValidator would accept any valid txid that was on
the chain, nothing was stopping a node from storing a history of past
payments and playing it back every time the other node restarted.

Now PaymentValidator rejects transactions it has previously validated
as well as any transaction that is greater than 6 or so hours old