### PR TITLE
Have peer listener wait for interfaces to be active

### DIFF
--- a/rita/src/rita_common/peer_listener/mod.rs
+++ b/rita/src/rita_common/peer_listener/mod.rs
@@ -7,22 +7,15 @@
 //! off the queue. These are turned into Peer structs which are passed to TunnelManager to do
 //! whatever remaining work there may be.
 
-use ::actix::prelude::*;
+use crate::rita_common::rita_loop::Tick;
+use crate::KI;
+use crate::SETTING;
 use ::actix::{Actor, Context};
+use ::actix::{Handler, Message, Supervised, SystemService};
 use failure::Error;
 use settings::RitaCommonSettings;
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6, UdpSocket};
-use std::thread::sleep;
-use std::time::{Duration, Instant};
-
-use althea_kernel_interface::KernelInterfaceError;
-
-use crate::rita_common::rita_loop::Tick;
-
-use crate::KI;
-use crate::SETTING;
-
 mod message;
 use self::message::PeerMessage;
 
@@ -70,20 +63,29 @@ impl PeerListener {
 
 impl Supervised for PeerListener {}
 
+impl PeerListener {
+    fn listen_to_available_ifaces(&mut self) {
+        let interfaces = SETTING.get_network().peer_interfaces.clone();
+        let iface_list = interfaces;
+        for iface in iface_list.iter() {
+            if !self.interfaces.contains_key(iface) {
+                match ListenInterface::new(iface) {
+                    Ok(new_listen_interface) => {
+                        self.interfaces
+                            .insert(new_listen_interface.ifname.clone(), new_listen_interface);
+                    }
+                    Err(_e) => {}
+                }
+            }
+        }
+    }
+}
+
 impl SystemService for PeerListener {
     // Binds to all ready interfaces
     fn service_started(&mut self, _ctx: &mut Context<Self>) {
         info!("PeerListener starting");
-        let interfaces = SETTING.get_network().peer_interfaces.clone();
-        let iface_list = interfaces;
-        for iface in iface_list.iter() {
-            let res = ListenInterface::new(iface);
-            if res.is_ok() {
-                let new_listen_interface = res.unwrap();
-                self.interfaces
-                    .insert(new_listen_interface.ifname.clone(), new_listen_interface);
-            }
-        }
+        self.listen_to_available_ifaces();
     }
 }
 
@@ -104,6 +106,8 @@ impl Handler<Tick> for PeerListener {
                 error!("Receiving ImHere failed with {:?}", e);
             }
         }
+
+        self.listen_to_available_ifaces();
 
         Ok(())
     }
@@ -195,41 +199,13 @@ pub struct ListenInterface {
     linklocal_ip: Ipv6Addr,
 }
 
-/// This function retries and error matches getting the link local ip for an interface. Since the operating
-/// system must add it there's an inherent race condition while we wait for the interfaces to come up. This
-/// tries to wait out and exit early when the interface fails for other reasons.
-fn try_link_ip(ifname: &str) -> Result<Ipv6Addr, Error> {
-    let now = Instant::now();
-    loop {
-        match KI.get_link_local_device_ip(ifname) {
-            Ok(link_ip) => return Ok(link_ip),
-            Err(KernelInterfaceError::AddressNotReadyError(_e)) => {
-                sleep(Duration::new(5, 0));
-                warn!(
-                    "Failed to get link local address on {:?} trying again in 5 seconds",
-                    ifname
-                );
-                if now.elapsed().as_secs() > 120 {
-                    panic!("Timed out waiting for fe80 address on interface {}. Interface exists but is incapable of meshing!", ifname);
-                }
-            }
-            Err(KernelInterfaceError::NoInterfaceError(e)) => {
-                return Err(KernelInterfaceError::NoInterfaceError(e).into());
-            }
-            Err(KernelInterfaceError::RuntimeError(e)) => {
-                return Err(KernelInterfaceError::RuntimeError(e).into());
-            }
-        }
-    }
-}
-
 impl ListenInterface {
     pub fn new(ifname: &str) -> Result<ListenInterface, Error> {
         let port = SETTING.get_network().rita_hello_port;
         let disc_ip = SETTING.get_network().discovery_ip;
         debug!("Binding to {:?} for ListenInterface", ifname);
         // Lookup interface link local ip
-        let link_ip = try_link_ip(&ifname)?;
+        let link_ip = KI.get_link_local_device_ip(&ifname)?;
 
         // Lookup interface index
         let iface_index = match KI.get_iface_index(&ifname) {
@@ -252,7 +228,7 @@ impl ListenInterface {
         );
 
         let linklocal_socketaddr = SocketAddrV6::new(link_ip, port, 0, iface_index);
-        let linklocal_socket = UdpSocket::bind(linklocal_socketaddr).unwrap_or_else(|_| panic!("ListenInterface Failed to bind to link local address {:?} on {:?} with iface_index {:?} ", link_ip, ifname, iface_index));
+        let linklocal_socket = UdpSocket::bind(linklocal_socketaddr)?;
         let res = linklocal_socket.set_nonblocking(true);
         trace!("ListenInterface init set nonblocking with {:?}", res);
 


### PR DESCRIPTION
This one is actually pretty strange, so the routers using their fake
switches typcially always have their mesh interfaces marked as 'up'
with fe80 addresses, but this is an artifect of the switches on
a system with independent interfaces we would at one point simply not
listen until a reboot had occured. Or in the case of more recent versions
crash.

This is a better handling situation in general.