### PR TITLE
Optimize DebtKeepers interactions with TunnelManager

### DIFF
--- a/babel_monitor/src/lib.rs
+++ b/babel_monitor/src/lib.rs
@@ -15,7 +15,7 @@ use std::net::TcpStream;
 use std::str;
 use std::time::Duration;
 
-const BABEL_OPERATION_TIMEOUT: Duration = Duration::from_secs(4);
+const BABEL_OPERATION_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Fail)]
 pub enum BabelMonitorError {


### PR DESCRIPTION
We where sending hundreds if not thousands of tunnel state change message every cycle. Hopefully this will address the unbounded slowdowns we've been seeing on the exits. 