### PR TITLE
Move one time wg_exit setup tasks into Rita Loop

### DIFF
--- a/althea_kernel_interface/src/lib.rs
+++ b/althea_kernel_interface/src/lib.rs
@@ -135,6 +135,21 @@ impl CommandRunner for LinuxCommandRunner {
             start.elapsed().as_secs(),
             start.elapsed().subsec_nanos() / 1000000
         );
+
+        if start.elapsed().as_secs() > 5 {
+            error!(
+                "Command {} {} took more than five seconds to complete!",
+                program,
+                print_str_array(args)
+            );
+        } else if start.elapsed().as_secs() > 1 {
+            warn!(
+                "Command {} {} took more than one second to complete!",
+                program,
+                print_str_array(args)
+            );
+        }
+
         return Ok(output);
     }
 

--- a/rita/src/rita_exit/database/mod.rs
+++ b/rita/src/rita_exit/database/mod.rs
@@ -449,8 +449,6 @@ pub fn setup_clients(clients_list: &[exit_db::models::Client]) -> Result<(), Err
         wg_clients,
         SETTING.get_exit_network().wg_tunnel_port,
         &SETTING.get_exit_network().wg_private_key_path,
-        &SETTING.get_exit_network().own_internal_ip.into(),
-        SETTING.get_exit_network().netmask,
     );
 
     match exit_status {

--- a/rita/src/rita_exit/network_endpoints/mod.rs
+++ b/rita/src/rita_exit/network_endpoints/mod.rs
@@ -35,9 +35,9 @@ pub fn setup_request(
         .1
         .connection_info()
         .remote()
-        .unwrap()
+        .expect("Failed in setup request")
         .parse()
-        .unwrap();
+        .expect("Failed in setup request");
 
     let remote_mesh_ip = remote_mesh_socket.ip();
     if remote_mesh_ip == client_mesh_ip {
@@ -50,7 +50,10 @@ pub fn setup_request(
 }
 
 pub fn status_request(their_id: Json<ExitClientIdentity>) -> Result<Json<ExitState>, Error> {
-    trace!("Received requester identity for status, {:?}", their_id);
+    trace!(
+        "Received requester identity for status, {}",
+        their_id.global.wg_public_key
+    );
     let client = their_id.into_inner();
 
     Ok(Json(client_status(client)?))

--- a/rita/src/rita_exit/traffic_watcher/mod.rs
+++ b/rita/src/rita_exit/traffic_watcher/mod.rs
@@ -42,12 +42,6 @@ impl Actor for TrafficWatcher {
 impl Supervised for TrafficWatcher {}
 impl SystemService for TrafficWatcher {
     fn service_started(&mut self, _ctx: &mut Context<Self>) {
-        if let Err(e) = KI.setup_wg_if_named("wg_exit") {
-            warn!("exit setup returned {}", e)
-        }
-        KI.setup_nat(&SETTING.get_network().external_nic.clone().unwrap())
-            .unwrap();
-
         info!("Traffic Watcher started");
     }
 }


### PR DESCRIPTION
So it turns out that the wg_exit setup loop is the primary source
of the slowdown I've been chasing, somehow it becomes slower and slower
overtime going from .5s to 14s over two days despite being a totally
sync call that shells out to wg and ip.

this moves one time setup tasks out and better instruments command
timings to dig deeper into the issue.