### PR TITLE
Update to clarity 1.5.5, num256 0.6.0, web30 1.12.4

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust tests
 
 on:
   push:
-    branches: [master]
+    branches: [beta20]
   pull_request:
-    branches: [master]
+    branches: [beta20]
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "actix-macros",
  "actix-rt",
  "actix_derive",
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "bytes",
  "crossbeam-channel",
  "futures-core",
@@ -33,7 +33,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -56,11 +56,11 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "base64 0.22.1",
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "brotli",
  "bytes",
  "bytestring",
- "derive_more 2.1.0",
+ "derive_more",
  "encoding_rs",
  "flate2",
  "foldhash",
@@ -91,7 +91,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
+checksum = "92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63"
 dependencies = [
  "actix-macros",
  "futures-core",
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca2549781d8dd6d75c40cf6b6051260a2cc2f3c62343d761a969a0640646894"
+checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -131,34 +131,33 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2 0.5.8",
+ "socket2 0.5.10",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "actix-service"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b894941f818cfdc7ccc4b9e60fa7e53b5042a2e8567270f9147d5591893373a"
+checksum = "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
 dependencies = [
  "futures-core",
- "paste",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "actix-tls"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac453898d866cdbecdbc2334fe1738c747b4eba14a677261f2b768ba05329389"
+checksum = "6176099de3f58fbddac916a7f8c6db297e021d706e7a6b99947785fee14abe9f"
 dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.4.0",
  "impl-more",
  "openssl",
  "pin-project-lite",
@@ -180,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.9.0"
+version = "4.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9180d76e5cc7ccbc4d60a506f2c727730b154010262df5b910eb17dbe4b8cb38"
+checksum = "1654a77ba142e37f049637a3e5685f864514af11fcbc51cb51eb6596afe5b8d6"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -192,12 +191,12 @@ dependencies = [
  "actix-service",
  "actix-tls",
  "actix-utils",
- "ahash",
  "bytes",
  "bytestring",
  "cfg-if",
- "derive_more 0.99.19",
+ "derive_more",
  "encoding_rs",
+ "foldhash",
  "futures-core",
  "futures-util",
  "impl-more",
@@ -212,8 +211,9 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.5.8",
+ "socket2 0.6.1",
  "time",
+ "tracing",
  "url",
 ]
 
@@ -240,42 +240,20 @@ checksum = "b6ac1e58cded18cb28ddc17143c4dea5345b3ad575e14f32f66e4054a56eb271"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "getrandom 0.2.15",
- "once_cell",
- "version_check",
- "zerocopy",
-]
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -403,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awc"
@@ -423,7 +401,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "cookie",
- "derive_more 2.1.0",
+ "derive_more",
  "futures-core",
  "futures-util",
  "h2",
@@ -459,24 +437,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "instant",
  "rand 0.8.5",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -530,9 +493,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "blake2"
@@ -550,6 +513,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -585,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byteorder"
@@ -597,15 +569,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "bytestring"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e465647ae23b2823b0753f50decb2d5a86d2bb2cac04788fafd1f80e45378e5f"
+checksum = "113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289"
 dependencies = [
  "bytes",
 ]
@@ -618,10 +590,11 @@ checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 
 [[package]]
 name = "cc"
-version = "1.2.14"
+version = "1.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
+checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -629,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -694,12 +667,6 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
@@ -745,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -767,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -810,9 +777,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -820,34 +787,22 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.5"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
+checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
 dependencies = [
- "nix 0.29.0",
- "windows-sys 0.59.0",
+ "dispatch2",
+ "nix 0.30.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
-dependencies = [
- "convert_case 0.4.0",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.98",
 ]
 
 [[package]]
@@ -865,11 +820,11 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d286bfdaf75e988b4a78e013ecd79c581e06399ab53fbacd2d916c2f904f30b"
 dependencies = [
- "convert_case 0.10.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.98",
+ "syn 2.0.111",
  "unicode-xid",
 ]
 
@@ -909,6 +864,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,7 +883,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -948,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "email-encoding"
@@ -998,12 +965,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1034,6 +1001,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,9 +1014,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1078,9 +1051,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -1148,7 +1121,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1222,32 +1195,26 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
+ "r-efi",
+ "wasip2",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
@@ -1285,14 +1252,14 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -1302,15 +1269,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1363,12 +1324,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1385,9 +1345,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -1397,9 +1357,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
@@ -1418,7 +1378,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.8",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1440,21 +1400,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1464,96 +1425,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
+ "icu_locale_core",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
 ]
 
 [[package]]
@@ -1568,9 +1491,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -1579,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1595,9 +1518,9 @@ checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1639,13 +1562,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.15"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
- "hermit-abi 0.4.0",
+ "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1659,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jemalloc-sys"
@@ -1685,18 +1608,19 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
+ "getrandom 0.3.4",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1750,9 +1674,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libsodium-sys"
@@ -1774,15 +1698,15 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-channel"
@@ -1803,19 +1727,18 @@ checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru-cache"
@@ -1854,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memoffset"
@@ -1890,30 +1813,31 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.4"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "native-tls"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -1945,11 +1869,23 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
  "memoffset 0.9.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -2055,28 +1991,34 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
 [[package]]
-name = "object"
-version = "0.36.7"
+name = "objc2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
 dependencies = [
- "memchr",
+ "objc2-encode",
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.20.3"
+name = "objc2-encode"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oncemutex"
@@ -2086,24 +2028,24 @@ checksum = "44d11de466f4a3006fe8a5e7ec84e93b79c70cb992ae0aa0eb631ad2df8abfe2"
 
 [[package]]
 name = "openssh-keys"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb830a82898b2ac17c9620ddce839ac3b34b9cb8a1a037cbdbfb9841c756c3e"
+checksum = "351339c4d45e6bdf2defef3ef1ce0b153810bd59b171b92b6a42e7bb0f32a4ad"
 dependencies = [
  "base64 0.21.7",
  "byteorder",
  "md-5",
  "sha2",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2120,7 +2062,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2131,18 +2073,18 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.2+3.4.1"
+version = "300.5.4+3.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
+checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
@@ -2164,9 +2106,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2174,45 +2116,38 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.7.15"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+checksum = "cbcfd20a6d4eeba40179f05735784ad32bdaef05ce8e8af05f180d45bb3e7e22"
 dependencies = [
  "memchr",
- "thiserror 2.0.11",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.15"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
+checksum = "51f72981ade67b1ca6adc26ec221be9f463f2b5839c7508998daa17c23d94d7f"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2220,24 +2155,23 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.15"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
+checksum = "dee9efd8cdb50d719a80088b76f81aec7c41ed6d522ee750178f83883d271625"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.15"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
+checksum = "bf1d70880e76bdc13ba52eafa6239ce793d85c8e43896507e43dd8984ff05b82"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
@@ -2269,7 +2203,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "strum",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -2286,9 +2220,18 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -2298,9 +2241,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
@@ -2316,27 +2259,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.37.2"
+version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -2346,6 +2289,12 @@ name = "quoted_printable"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3866219251662ec3b26fc217e3e05bf9c4f84325234dfb96bf0bf840889e49"
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r2d2"
@@ -2405,7 +2354,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -2414,39 +2363,39 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.1",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.8",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.8",
 ]
 
 [[package]]
@@ -2463,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "regex-lite"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
 
 [[package]]
 name = "regex-syntax"
@@ -2475,9 +2424,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
@@ -2687,12 +2636,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2703,15 +2646,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2725,15 +2668,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -2746,11 +2689,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2794,7 +2737,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2803,9 +2746,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2813,16 +2756,17 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -2837,26 +2781,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.217"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2905,9 +2859,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2932,9 +2886,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
 dependencies = [
  "libc",
 ]
@@ -2946,19 +2900,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
-name = "slab"
-version = "0.4.9"
+name = "simd-adler32"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -2972,12 +2929,22 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2994,9 +2961,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -3023,7 +2990,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3045,9 +3012,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3062,13 +3029,13 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3094,16 +3061,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
- "cfg-if",
  "fastrand 2.3.0",
- "getrandom 0.3.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3140,16 +3106,7 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
-dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -3160,25 +3117,14 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
@@ -3191,15 +3137,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3207,9 +3153,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3217,9 +3163,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3232,31 +3178,30 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.8",
+ "socket2 0.6.1",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3282,9 +3227,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3310,20 +3255,32 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
-name = "tracing-core"
-version = "0.1.33"
+name = "tracing-attributes"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
 ]
@@ -3336,9 +3293,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "ucd-trie"
@@ -3354,15 +3311,15 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
@@ -3381,20 +3338,15 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
- "idna 1.0.3",
+ "idna 1.1.0",
  "percent-encoding",
+ "serde",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -3404,11 +3356,13 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.13.2"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f41ffb7cf259f1ecc2876861a17e7142e63ead296f671f81f6ae85903e0d6"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
- "getrandom 0.3.1",
+ "getrandom 0.3.4",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3444,50 +3398,37 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3498,9 +3439,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3508,31 +3449,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
- "wasm-bindgen-backend",
+ "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3581,11 +3522,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3593,6 +3534,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -3614,11 +3561,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -3645,11 +3601,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3665,6 +3638,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3675,6 +3654,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3689,10 +3674,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3707,6 +3704,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3717,6 +3720,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3731,6 +3740,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3743,6 +3758,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3753,33 +3774,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.33.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
-dependencies = [
- "bitflags 2.8.0",
-]
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -3787,63 +3798,73 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
  "synstructure",
 ]
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3852,38 +3873,38 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "zstd"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.1"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,24 +46,24 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.9.0"
+version = "3.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48f96fc3003717aeb9856ca3d02a8c7de502667ad76eeacd830b48d2e91fac4"
+checksum = "7926860314cbe2fb5d1f13731e387ab43bd32bca224e82e6e2db85de0a3dba49"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-tls",
  "actix-utils",
- "ahash",
  "base64 0.22.1",
  "bitflags 2.8.0",
  "brotli",
  "bytes",
  "bytestring",
- "derive_more",
+ "derive_more 2.1.0",
  "encoding_rs",
  "flate2",
+ "foldhash",
  "futures-core",
  "h2",
  "http 0.2.12",
@@ -75,7 +75,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.9.2",
  "sha1",
  "smallvec",
  "tokio",
@@ -196,7 +196,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "cfg-if",
- "derive_more",
+ "derive_more 0.99.19",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -329,7 +329,7 @@ dependencies = [
  "lettre",
  "num256",
  "phonenumber",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "serde_json",
@@ -348,7 +348,7 @@ dependencies = [
  "lazy_static",
  "log",
  "oping",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sodiumoxide",
@@ -362,7 +362,7 @@ dependencies = [
  "clarity",
  "lazy_static",
  "log",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "serde_json",
@@ -394,7 +394,7 @@ dependencies = [
  "log",
  "num",
  "num256",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "tokio",
@@ -409,9 +409,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "awc"
-version = "3.5.1"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79049b2461279b886e46f1107efc347ebecc7b88d74d023dda010551a124967b"
+checksum = "3c170039c11c7f6c0a28f7b3bd4fb0c674cbfa317fabc1560022ad3ec2d69e7c"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -423,7 +423,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "cookie",
- "derive_more",
+ "derive_more 2.1.0",
  "futures-core",
  "futures-util",
  "h2",
@@ -434,7 +434,7 @@ dependencies = [
  "openssl",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -461,7 +461,7 @@ checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "getrandom 0.2.15",
  "instant",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -507,6 +507,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-io"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,10 +553,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli"
-version = "6.0.0"
+name = "bnum"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+checksum = "29ed1ec45f6ef6e8d1125cc2c2fec8f8fe7d4fa5b262f15885fdccb9e26f0f15"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -549,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -615,19 +641,14 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clarity"
-version = "0.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4571596842d9326a73c215e81b36c7c6e110656ce7aa905cb4df495f138ff71"
+checksum = "7edff20e8fcef653d73b27daa01accbbe0dec2c00cc12b63516b85df514ed342"
 dependencies = [
- "byteorder",
- "lazy_static",
- "num",
- "num-bigint",
  "num-traits",
  "num256",
  "secp256k1",
  "serde",
- "serde_bytes",
  "serde_derive",
  "sha3",
 ]
@@ -643,7 +664,7 @@ dependencies = [
  "ipgen",
  "lazy_static",
  "log",
- "rand",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde_derive",
@@ -676,6 +697,15 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie"
@@ -813,11 +843,34 @@ version = "0.99.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b768e943bed7bf2cab53df09f4bc34bfd217cdb57d971e769874c9a6710618"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d286bfdaf75e988b4a78e013ecd79c581e06399ab53fbacd2d916c2f904f30b"
+dependencies = [
+ "convert_case 0.10.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.98",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1001,6 +1054,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1192,9 +1251,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",
@@ -1258,6 +1317,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "hex-literal"
@@ -1916,7 +1984,6 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -1933,17 +2000,6 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "num-integer"
@@ -1987,16 +2043,14 @@ dependencies = [
 
 [[package]]
 name = "num256"
-version = "0.3.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9b5179e82f0867b23e0b9b822493821f9345561f271364f409c8e4a058367d"
+checksum = "85228c87555ed4e5ddf024e9ef1908b27458b97e56b195af0d9cf1d7db890023"
 dependencies = [
- "lazy_static",
- "num",
- "num-derive",
+ "bnum",
+ "num-integer",
  "num-traits",
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -2311,8 +2365,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2322,7 +2386,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2332,6 +2406,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
 ]
 
 [[package]]
@@ -2499,7 +2582,7 @@ dependencies = [
  "num256",
  "openssh-keys",
  "phonenumber",
- "rand",
+ "rand 0.8.5",
  "rita_common",
  "serde",
  "serde_derive",
@@ -2540,7 +2623,7 @@ dependencies = [
  "log",
  "num-traits",
  "num256",
- "rand",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde_cbor",
@@ -2573,7 +2656,7 @@ dependencies = [
  "num256",
  "phonenumber",
  "r2d2",
- "rand",
+ "rand 0.8.5",
  "reqwest",
  "rita_common",
  "serde",
@@ -2687,18 +2770,20 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secp256k1"
-version = "0.25.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550fc3b723a478be77bf74718947cdcdd75144d508aaa70f0a320036905df2a8"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.2",
  "secp256k1-sys",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.7.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8058e28ae464daf5ac14c5c0f78110b58616e796c4e4e28cfcca38fdb13d8f22"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -2739,15 +2824,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -3292,6 +3368,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3452,16 +3540,16 @@ dependencies = [
 
 [[package]]
 name = "web30"
-version = "0.22.0"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b5db33bc4a6465d2111c276858700924031c09d0fbf633d693189d88361d7a5"
+checksum = "5d97b85e6a96c2b0b6e645bd25eaedd42cbfd3e11f045248ba42e2de697c05fd"
 dependencies = [
  "awc",
  "clarity",
  "futures 0.3.31",
  "lazy_static",
  "log",
- "num",
+ "num-traits",
  "num256",
  "serde",
  "serde_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "rita_bin"
-version = "0.20.39"
+version = "0.20.40"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "rita_client"
-version = "0.20.39"
+version = "0.20.40"
 dependencies = [
  "actix",
  "actix-web",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "rita_common"
-version = "0.20.39"
+version = "0.20.40"
 dependencies = [
  "actix",
  "actix-service",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "rita_exit"
-version = "0.20.39"
+version = "0.20.40"
 dependencies = [
  "actix",
  "actix-web",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "rita_extender"
-version = "0.20.39"
+version = "0.20.40"
 dependencies = [
  "actix",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,15 @@ edition = "2018"
 [workspace]
 members = ["althea_kernel_interface", "settings", "clu", "exit_db", "antenna_forwarding_client", "antenna_forwarding_protocol", "auto_bridge","rita_common","rita_exit","rita_client", "rita_bin", "test_runner"]
 
+[workspace.dependencies]
+clarity = "1.5.5"
+num256 = "0.6.0"
+web30 = "1.12.4"
+
 [profile.release]
 opt-level = "z"
 strip = true
 lto = true
 codegen-units=1
 incremental = false
+

--- a/althea_types/Cargo.toml
+++ b/althea_types/Cargo.toml
@@ -8,14 +8,14 @@ license = "Apache-2.0"
 
 [dependencies]
 babel_monitor = { path = "../babel_monitor" }
-num256 = "0.3"
+num256 = { workspace = true }
 base64 = "0.13"
 serde_derive = "1.0"
 serde = "1.0"
 serde_json = "1.0"
 hex = "0.4"
 sodiumoxide = "0.2"
-clarity = "0.5"
+clarity = { workspace = true }
 arrayvec = {version= "0.7", features = ["serde"]}
 phonenumber = "0.3"
 lettre = {version = "0.10", features = ["serde"]}

--- a/antenna_forwarding_protocol/Cargo.toml
+++ b/antenna_forwarding_protocol/Cargo.toml
@@ -10,7 +10,7 @@ serde_json = "1.0"
 serde_derive = "1.0"
 serde = "1.0"
 sodiumoxide = "0.2"
-clarity = "0.5"
+clarity = { workspace = true }
 log = "0.4"
 lazy_static = "1.4"
 

--- a/auto_bridge/Cargo.toml
+++ b/auto_bridge/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Jehan <jehan.tremback@gmail.com>, Justin <justin@althea.net>"]
 edition = "2018"
 
 [dependencies]
-web30 = "0.22"
-num256 = "0.3"
-clarity = "0.5"
+web30 = { workspace = true }
+num256 = { workspace = true }
+clarity = { workspace = true }
 rand = "0.8"
 num = "0.4"
 log = "0.4"

--- a/auto_bridge/src/lib.rs
+++ b/auto_bridge/src/lib.rs
@@ -3,16 +3,16 @@ extern crate log;
 #[macro_use]
 extern crate serde_derive;
 
-use clarity::abi::{encode_call, Token};
+use clarity::abi::{encode_call, AbiToken};
 use clarity::utils::bytes_to_hex_str;
 use clarity::{Address, PrivateKey};
 use num256::Uint256;
 use std::collections::HashSet;
-use std::time::Duration;
-use web30::amm::{DAI_CONTRACT_ADDRESS as DAI_CONTRACT_ON_ETH, USDC_CONTRACT_ADDRESS};
+use std::time::{Duration, Instant};
+use web30::amm::{USDC_CONTRACT_ADDRESS, USDS_CONTRACT_ADDRESS as USDS_CONTRACT_ON_ETH};
 use web30::client::Web3;
 use web30::jsonrpc::error::Web3Error;
-use web30::types::Log;
+use web30::types::{Log, TransactionRequest, TransactionResponse};
 
 mod error;
 pub use error::TokenBridgeError;
@@ -23,10 +23,12 @@ pub use error::TokenBridgeError;
 pub static UNISWAP_GAS_LIMIT: u128 = 150_000;
 pub static ERC20_GAS_LIMIT: u128 = 40_000;
 pub static XDAI_FUNDS_UNLOCK_GAS: u128 = 180_000;
-/// Minimum transfer is $5 dai which has 18 decimal precision
-pub static MINIMUM_DAI_TO_SEND: u128 = 2_000_000_000_000_000_000;
-/// Minimum transfer is $15 USDC which has 6 decimal precision
-pub static MINIMUM_USDC_TO_CONVERT: u128 = 15_000_000;
+/// Minimum transfer is 50c usds which has 18 decimal precision
+pub static MINIMUM_USDS_TO_SEND: u128 = 500_000_000_000_000_000;
+/// Minimum swap is 50c USDC which has 6 decimal precision
+pub static MINIMUM_USDC_TO_CONVERT: u128 = 500_000;
+/// Minimum swap 50c DAI which has 18 decimal precision
+pub static MINIMUM_DAI_TO_CONVERT: u128 = 500_000_000_000_000_000;
 
 fn default_helper_on_xdai_address() -> Address {
     default_bridge_addresses().helper_on_xdai
@@ -53,9 +55,7 @@ pub struct TokenBridgeAddresses {
 }
 
 pub fn get_usdt_address() -> Address {
-    "0xdAC17F958D2ee523a2206206994597C13D831ec7"
-        .parse()
-        .unwrap()
+    *web30::amm::USDT_CONTRACT_ADDRESS
 }
 
 /// Just a little helper struct to keep us from getting
@@ -108,46 +108,68 @@ impl TokenBridge {
         }
     }
 
-    /// Bridge `dai_amount` dai to xdai
-    pub async fn dai_to_xdai_bridge(
+    /// Bridge `usds_amount` usds to xdai
+    pub async fn usds_to_xdai_bridge(
         &self,
-        dai_amount: Uint256,
+        usds_amount: Uint256,
         timeout: Duration,
     ) -> Result<Uint256, TokenBridgeError> {
-        let own_address = self.own_address;
         let secret = self.eth_privatekey;
 
-        // You basically just send it some dai to the bridge address and they show
-        // up in the same address on the xdai side we have no idea when this has succeeded
-        // since the events are not indexed
-        let tx_hash = self
+        let allowance = self
             .eth_web3
-            .send_transaction(
-                *DAI_CONTRACT_ON_ETH,
+            .get_erc20_allowance(
+                *USDS_CONTRACT_ON_ETH,
+                self.eth_privatekey.to_address(),
+                self.xdai_bridge_on_eth,
+                vec![],
+            )
+            .await?;
+        trace!("Current USDS allowance on the bridge is {}", allowance);
+        if usds_amount > allowance {
+            trace!("Executing approval for USDS transfer");
+            // approve 1000 usds at a time, this reduces gas costs for the user
+            self.eth_web3
+                .erc20_approve(
+                    *USDS_CONTRACT_ON_ETH,
+                    // 1000 usds
+                    1000000000000000000000u128.into(),
+                    self.eth_privatekey,
+                    self.xdai_bridge_on_eth,
+                    Some(timeout),
+                    vec![],
+                )
+                .await?;
+        }
+
+        let tx = self
+            .eth_web3
+            .prepare_transaction(
+                self.xdai_bridge_on_eth,
                 encode_call(
-                    "transfer(address,uint256)",
-                    &[self.xdai_bridge_on_eth.into(), dai_amount.clone().into()],
+                    "relayTokens(address,uint256)",
+                    &[self.eth_privatekey.to_address().into(), usds_amount.into()],
                 )
                 .unwrap(),
                 0u32.into(),
-                own_address,
                 secret,
-                Vec::new(),
+                vec![],
             )
             .await?;
+        let tx_hash = self.eth_web3.send_prepared_transaction(tx).await?;
 
         self.eth_web3
             .wait_for_transaction(tx_hash, timeout, None)
             .await?;
 
-        Ok(dai_amount)
+        Ok(usds_amount)
     }
 
-    pub async fn get_dai_balance(&self) -> Result<Uint256, TokenBridgeError> {
-        let dai_address = *DAI_CONTRACT_ON_ETH;
+    pub async fn get_usds_balance(&self) -> Result<Uint256, TokenBridgeError> {
+        let usds_address = *USDS_CONTRACT_ON_ETH;
         Ok(self
             .eth_web3
-            .get_erc20_balance(dai_address, self.own_address)
+            .get_erc20_balance(usds_address, self.own_address, vec![])
             .await?)
     }
 
@@ -155,15 +177,24 @@ impl TokenBridge {
         let usdc_address = *USDC_CONTRACT_ADDRESS;
         Ok(self
             .eth_web3
-            .get_erc20_balance(usdc_address, self.own_address)
+            .get_erc20_balance(usdc_address, self.own_address, vec![])
             .await?)
     }
 
     pub async fn get_usdt_balance(&self) -> Result<Uint256, TokenBridgeError> {
-        let usdt_address = get_usdt_address();
+        let usdt_address = *web30::amm::USDT_CONTRACT_ADDRESS;
         Ok(self
             .eth_web3
-            .get_erc20_balance(usdt_address, self.own_address)
+            .get_erc20_balance(usdt_address, self.own_address, vec![])
+            .await?)
+    }
+
+    /// DAI is a token we support swapping to USDS before bridging over to xdai (now Gnosischain)
+    pub async fn get_dai_balance(&self) -> Result<Uint256, TokenBridgeError> {
+        let dai_address = *web30::amm::DAI_CONTRACT_ADDRESS;
+        Ok(self
+            .eth_web3
+            .get_erc20_balance(dai_address, self.own_address, vec![])
             .await?)
     }
 
@@ -173,7 +204,6 @@ impl TokenBridge {
         data: HelperWithdrawInfo,
         timeout: Duration,
     ) -> Result<Uint256, TokenBridgeError> {
-        let own_address = self.own_address;
         let payload = get_payload_for_funds_unlock(&data);
         trace!(
             "bridge unlocking funds with! {} bytes payload! {}",
@@ -181,21 +211,21 @@ impl TokenBridge {
             bytes_to_hex_str(&payload),
         );
 
-        let txid = self
+        let tx = self
             .eth_web3
-            .send_transaction(
+            .prepare_transaction(
                 self.xdai_bridge_on_eth,
                 payload,
                 0u32.into(),
-                own_address,
                 self.eth_privatekey,
                 Vec::new(),
             )
             .await?;
+        let txid = self.eth_web3.send_prepared_transaction(tx).await?;
 
         let _ = self
             .eth_web3
-            .wait_for_transaction(txid.clone(), timeout, None)
+            .wait_for_transaction(txid, timeout, None)
             .await;
         Ok(txid)
     }
@@ -221,7 +251,7 @@ pub async fn get_relay_message_hash(
         &[
             dest_address.into(),
             amount_sent.into(),
-            Token::Bytes(xdai_withdraw_txid.to_bytes_be()),
+            AbiToken::Bytes(xdai_withdraw_txid.to_be_bytes().to_vec()),
         ],
     ) {
         Ok(a) => a,
@@ -232,11 +262,15 @@ pub async fn get_relay_message_hash(
         }
     };
     let msg_hash = xdai_web3
-        .simulate_transaction(helper_on_xdai, 0_u32.into(), payload, own_address, None)
+        .simulate_transaction(
+            TransactionRequest::quick_tx(own_address, helper_on_xdai, payload),
+            vec![],
+            None,
+        )
         .await?;
     // this may return 0x0 if the value is not yet ready, in this case
     // we fail with a not ready error
-    let payload = match encode_call("getMessage(bytes32)", &[Token::Bytes(msg_hash.clone())]) {
+    let payload = match encode_call("getMessage(bytes32)", &[AbiToken::Bytes(msg_hash.clone())]) {
         Ok(a) => a,
         Err(e) => {
             return Err(TokenBridgeError::Web3Error(Web3Error::BadInput(format!(
@@ -245,14 +279,18 @@ pub async fn get_relay_message_hash(
         }
     };
     let msg = xdai_web3
-        .simulate_transaction(helper_on_xdai, 0_u32.into(), payload, own_address, None)
+        .simulate_transaction(
+            TransactionRequest::quick_tx(own_address, helper_on_xdai, payload),
+            vec![],
+            None,
+        )
         .await?;
 
     if msg == vec![0] || msg.len() <= 64 {
         return Err(TokenBridgeError::HelperMessageNotReady);
     }
 
-    let payload = match encode_call("getSignatures(bytes32)", &[Token::Bytes(msg_hash)]) {
+    let payload = match encode_call("getSignatures(bytes32)", &[AbiToken::Bytes(msg_hash)]) {
         Ok(a) => a,
         Err(e) => {
             return Err(TokenBridgeError::Web3Error(Web3Error::BadInput(format!(
@@ -261,7 +299,11 @@ pub async fn get_relay_message_hash(
         }
     };
     let sigs_payload = xdai_web3
-        .simulate_transaction(helper_on_xdai, 0_u32.into(), payload, own_address, None)
+        .simulate_transaction(
+            TransactionRequest::quick_tx(own_address, helper_on_xdai, payload),
+            vec![],
+            None,
+        )
         .await?;
     if sigs_payload == vec![0] || sigs_payload.len() <= 64 {
         return Err(TokenBridgeError::HelperMessageNotReady);
@@ -274,8 +316,8 @@ pub async fn get_relay_message_hash(
     //  1. discard the first uint256 type specifier, we know what we have
     //  2. take the second uint256 it's the length in bytes of the rest of the message
     //  3. take the bytes between START (2 uint256 offset) and END (offset plus message length)
-    let msg_len = Uint256::from_bytes_be(&msg[32..64]);
-    let sigs_len = Uint256::from_bytes_be(&sigs_payload[32..64]);
+    let msg_len = Uint256::from_be_bytes(&msg[32..64]);
+    let sigs_len = Uint256::from_be_bytes(&sigs_payload[32..64]);
     if msg_len > usize::MAX.into() || sigs_len > usize::MAX.into() {
         return Err(TokenBridgeError::HelperMessageIncorrect);
     }
@@ -300,8 +342,8 @@ pub fn get_payload_for_funds_unlock(data: &HelperWithdrawInfo) -> Vec<u8> {
     encode_call(
         "executeSignatures(bytes,bytes)",
         &[
-            Token::UnboundedBytes(data.msg.clone()),
-            Token::UnboundedBytes(data.sigs.clone()),
+            AbiToken::UnboundedBytes(data.msg.clone()),
+            AbiToken::UnboundedBytes(data.sigs.clone()),
         ],
     )
     .unwrap()
@@ -338,7 +380,11 @@ pub async fn check_relayed_message(
     };
 
     let res = web3
-        .simulate_transaction(contract, 0_u32.into(), payload, own_address, None)
+        .simulate_transaction(
+            TransactionRequest::quick_tx(own_address, contract, payload),
+            vec![],
+            None,
+        )
         .await?;
 
     // if last entry of vector is 1, true, else false
@@ -361,17 +407,17 @@ pub async fn encode_relaytokens(
     let payload = encode_call("relayTokens(address)", &[dest_address.into()]).unwrap();
     let options = Vec::new();
 
-    let tx_hash = bridge
+    let tx = bridge
         .xdai_web3
-        .send_transaction(
+        .prepare_transaction(
             bridge.xdai_bridge_on_xdai,
             payload,
             amount,
-            bridge.own_address,
             bridge.eth_privatekey,
             options,
         )
         .await?;
+    let tx_hash = bridge.xdai_web3.send_prepared_transaction(tx).await?;
 
     bridge
         .xdai_web3
@@ -388,11 +434,11 @@ fn compute_start_end(
     total_blocks: u64,
     max_iter: u64,
 ) -> (Uint256, Uint256) {
-    let start_block = (latest_block.clone() - total_blocks.into()) + (max_iter * iter).into();
-    let end_block = if start_block.clone() + max_iter.into() > latest_block {
+    let start_block = (latest_block - total_blocks.into()) + (max_iter * iter).into();
+    let end_block = if start_block + max_iter.into() > latest_block {
         latest_block
     } else {
-        start_block.clone() + max_iter.into()
+        start_block + max_iter.into()
     };
 
     (start_block, end_block)
@@ -434,11 +480,16 @@ pub async fn check_withdrawals(
     contract: Address,
     xdai_web3: Web3,
     search_addresses: HashSet<Address>,
+    // The total amount of time this operation has to complete
+    // during that time failed requests will be retried
+    // if None exit will occur on the first error
+    retry_timeout: Option<Duration>,
 ) -> Result<Vec<WithdrawEvent>, Web3Error> {
     /// Total number of blocks on the xdai blockchain we retrieve at once. If the blocks to check is greater than this we loop.
-    const MAX_ITER: u64 = 10_000;
+    const MAX_ITER: u64 = 500;
     let mut blocks_left: u64 = blocks_to_check;
     let mut vec_of_withdraws = Vec::new();
+    let start_time = Instant::now();
 
     //get latest xdai block
     let xdai_client = xdai_web3;
@@ -447,18 +498,24 @@ pub async fn check_withdrawals(
 
     // iterate MAX_ITER blocks at a time
     loop {
-        let (start, end) =
-            compute_start_end(iter, xdai_latest_block.clone(), blocks_to_check, MAX_ITER);
+        let (start, end) = compute_start_end(iter, xdai_latest_block, blocks_to_check, MAX_ITER);
         iter += 1;
 
         //We search for the phrase UserRequestForSignature(_receiver,valueToTransfer)
         let phrase_sig = "UserRequestForSignature(address,uint256)";
 
-        let logs = xdai_client
+        let mut logs = xdai_client
             .check_for_events(start, Some(end), vec![contract], vec![phrase_sig])
-            .await?;
+            .await;
+        if let Some(timeout) = retry_timeout {
+            while logs.is_err() && (Instant::now() - start_time) < timeout {
+                logs = xdai_client
+                    .check_for_events(start, Some(end), vec![contract], vec![phrase_sig])
+                    .await;
+            }
+        }
 
-        for log in logs.iter() {
+        for log in logs?.iter() {
             let withdraw_event = parse_withdraw_event(log, &xdai_client).await?;
             for &search_address in search_addresses.iter() {
                 if withdraw_event.sender == search_address {
@@ -492,7 +549,7 @@ fn parse_receiver_data(data: &[u8]) -> Result<(Address, Uint256), Web3Error> {
 
     // The next word in payload represents the ammount. this is bytes 32 - 64
     let ammount_bytes = &data[32..64];
-    let ammount = Uint256::from_bytes_be(ammount_bytes);
+    let ammount = Uint256::from_be_bytes(ammount_bytes);
 
     Ok((address, ammount))
 }
@@ -507,8 +564,8 @@ async fn parse_sender_data(data: &[u8], client: &Web3) -> Result<(Address, Uint2
         ));
     }
 
-    let tx_hash = Uint256::from_bytes_be(data);
-    let response = client.eth_get_transaction_by_hash(tx_hash.clone()).await?;
+    let tx_hash = Uint256::from_be_bytes(data);
+    let response = client.eth_get_transaction_by_hash(tx_hash).await?;
 
     let tx_res = match response {
         Some(a) => a,
@@ -519,7 +576,11 @@ async fn parse_sender_data(data: &[u8], client: &Web3) -> Result<(Address, Uint2
         }
     };
 
-    let sender = tx_res.from;
+    let sender = match tx_res {
+        TransactionResponse::Eip1559 { from, .. } => from,
+        TransactionResponse::Eip2930 { from, .. } => from,
+        TransactionResponse::Legacy { from, .. } => from,
+    };
     Ok((sender, tx_hash))
 }
 
@@ -691,7 +752,7 @@ mod tests {
 
     #[test]
     #[ignore]
-    fn test_dai_to_xdai_bridge() {
+    fn test_usds_to_xdai_bridge() {
         let runner = actix::System::new();
 
         let token_bridge = new_token_bridge();
@@ -700,7 +761,7 @@ mod tests {
             // All we can really do here is test that it doesn't throw. Check your balances in
             // 5-10 minutes to see if the money got transferred.
             token_bridge
-                .dai_to_xdai_bridge(eth_to_wei(0.01f64), TIMEOUT)
+                .usds_to_xdai_bridge(eth_to_wei(0.01f64), TIMEOUT)
                 .await
                 .unwrap();
         });
@@ -713,7 +774,7 @@ mod tests {
 
         let token_bridge = new_token_bridge();
 
-        let blocks_to_check = 10000;
+        let blocks_to_check = 100_000;
         runner.block_on(async move {
             let mut h = HashSet::new();
             h.insert(token_bridge.own_address);
@@ -723,6 +784,7 @@ mod tests {
                 token_bridge.xdai_bridge_on_xdai,
                 token_bridge.xdai_web3,
                 h,
+                Some(Duration::from_secs(600)),
             )
             .await
             .unwrap();
@@ -752,7 +814,7 @@ mod tests {
         let (address, ammount) = parse_receiver_data(&data).unwrap();
 
         assert_eq!(address, Address::from_slice(&address_bytes).unwrap());
-        assert_eq!(ammount, Uint256::from_bytes_be(&ammount_bytes));
+        assert_eq!(ammount, Uint256::from_be_bytes(&ammount_bytes));
 
         assert_eq!(address.as_bytes(), address_bytes);
     }
@@ -768,31 +830,26 @@ mod tests {
             let xdai_client = Web3::new("https://dai.althea.net", Duration::from_secs(5));
             let latest_block = xdai_client.eth_block_number().await.unwrap();
 
-            let (start, end) =
-                compute_start_end(0, latest_block.clone(), blocks_to_search, max_iter);
-            assert_eq!(start, latest_block.clone() - blocks_to_search.into());
+            let (start, end) = compute_start_end(0, latest_block, blocks_to_search, max_iter);
+            assert_eq!(start, latest_block - blocks_to_search.into());
             assert_eq!(end, start + max_iter.into());
 
             blocks_to_search = 9999;
-            let (start, end) =
-                compute_start_end(0, latest_block.clone(), blocks_to_search, max_iter);
-            assert_eq!(start, latest_block.clone() - blocks_to_search.into());
+            let (start, end) = compute_start_end(0, latest_block, blocks_to_search, max_iter);
+            assert_eq!(start, latest_block - blocks_to_search.into());
             assert_eq!(end, start + blocks_to_search.into());
 
             blocks_to_search = 10000;
-            let (start, end) =
-                compute_start_end(0, latest_block.clone(), blocks_to_search, max_iter);
-            assert_eq!(start, latest_block.clone() - blocks_to_search.into());
+            let (start, end) = compute_start_end(0, latest_block, blocks_to_search, max_iter);
+            assert_eq!(start, latest_block - blocks_to_search.into());
             assert_eq!(end, start + blocks_to_search.into());
 
             blocks_to_search = 10001;
-            let (start, end) =
-                compute_start_end(0, latest_block.clone(), blocks_to_search, max_iter);
-            assert_eq!(start, latest_block.clone() - blocks_to_search.into());
+            let (start, end) = compute_start_end(0, latest_block, blocks_to_search, max_iter);
+            assert_eq!(start, latest_block - blocks_to_search.into());
             assert_eq!(end, start + max_iter.into());
 
-            let (start, end) =
-                compute_start_end(1, latest_block.clone(), blocks_to_search, max_iter);
+            let (start, end) = compute_start_end(1, latest_block, blocks_to_search, max_iter);
             assert_eq!(start, latest_block - 1u32.into());
             assert_eq!(end, start + 1u32.into());
         });

--- a/clu/Cargo.toml
+++ b/clu/Cargo.toml
@@ -16,7 +16,7 @@ rand = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-clarity = "0.5"
+clarity = { workspace = true }
 sodiumoxide = "0.2"
 
 [dependencies.regex]

--- a/clu/src/lib.rs
+++ b/clu/src/lib.rs
@@ -15,7 +15,7 @@ use std::fs::File;
 use std::io::Read;
 use std::net::IpAddr;
 use std::path::Path;
-use std::{str, thread};
+use std::thread;
 
 mod error;
 pub use error::NewCluError;
@@ -44,6 +44,18 @@ pub fn generate_mesh_ip() -> Result<IpAddr, NewCluError> {
     info!("Generated a new mesh IP address: {}", mesh_ip);
 
     Ok(mesh_ip)
+}
+
+pub fn generate_eth_key() -> PrivateKey {
+    // this loop should never execute more than twice, if it does the random number generator
+    // is in poor shape
+    loop {
+        let key_buf: [u8; 32] = rand::random();
+        let new_private_key = PrivateKey::from_bytes(key_buf);
+        if let Ok(key) = new_private_key {
+            return key;
+        }
+    }
 }
 
 pub fn validate_mesh_ip(ip: &IpAddr) -> bool {
@@ -94,9 +106,9 @@ pub fn del_multiple_interfaces_sync(interfaces: Vec<String>) -> Result<(), NewCl
 pub fn del_multiple_interfaces(interfaces: Vec<String>) {
     const BATCH_SIZE: usize = 50;
     let mut batched_interfaces: Vec<Vec<String>> = Vec::new();
-    let mut iter = interfaces.iter();
+    let iter = interfaces.iter();
     let mut current_batch = Vec::new();
-    while let Some(name) = iter.next() {
+    for name in iter {
         current_batch.push(name.clone());
         if current_batch.len() >= BATCH_SIZE {
             batched_interfaces.push(current_batch);
@@ -227,11 +239,9 @@ fn linux_init(settings: RitaClientSettings) -> Result<RitaClientSettings, NewClu
         }
         None => {
             info!("Eth key details not configured, generating");
-            let key_buf: [u8; 32] = rand::random();
-            let new_private_key = PrivateKey::from_slice(&key_buf)?;
+            let new_private_key = generate_eth_key();
             payment_settings.eth_private_key = Some(new_private_key);
-
-            payment_settings.eth_address = Some(new_private_key.to_address())
+            payment_settings.eth_address = Some(new_private_key.to_address());
         }
     }
 
@@ -310,15 +320,17 @@ fn linux_exit_init(
         None => {
             info!("Eth key details not configured, generating");
             let key_buf: [u8; 32] = rand::random();
-            let new_private_key = PrivateKey::from_slice(&key_buf)?;
+            let new_private_key = PrivateKey::from_bytes(key_buf)?;
             payment_settings.eth_private_key = Some(new_private_key);
 
             payment_settings.eth_address = Some(new_private_key.to_address())
         }
     }
+
     settings.payment = payment_settings;
     settings.network = network_settings;
     settings.exit_network = exit_network_settings;
+
     trace!("Starting with settings (after clu) : {:?}", settings);
     assert!(settings.get_identity().is_some());
     Ok(settings)
@@ -327,14 +339,14 @@ fn linux_exit_init(
 pub fn init(platform: &str, settings: RitaClientSettings) -> RitaClientSettings {
     match platform {
         "linux" => linux_init(settings).unwrap(),
-        _ => unimplemented!(),
+        _ => panic!("Platform not supported"),
     }
 }
 
 pub fn exit_init(platform: &str, settings: RitaExitSettingsStruct) -> RitaExitSettingsStruct {
     match platform {
         "linux" => linux_exit_init(settings).unwrap(),
-        _ => unimplemented!(),
+        _ => panic!("Platform not supported"),
     }
 }
 
@@ -353,7 +365,7 @@ mod tests {
         let mut history = HashSet::new();
         for _ in 0..1000 {
             let ip = generate_mesh_ip().unwrap();
-            if history.get(&ip).is_some() {
+            if history.contains(&ip) {
                 panic!("Got duplicate ip {}", ip)
             } else {
                 history.insert(ip);

--- a/rita_bin/Cargo.toml
+++ b/rita_bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rita_bin"
-version = "0.20.39"
+version = "0.20.40"
 edition = "2018"
 license = "Apache-2.0"
 build = "build.rs"

--- a/rita_client/Cargo.toml
+++ b/rita_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rita_client"
-version = "0.20.39"
+version = "0.20.40"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/rita_client/Cargo.toml
+++ b/rita_client/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 [dependencies]
 compressed_log = "0.5"
 num-traits="0.2"
-num256 = "0.3"
+num256 = { workspace = true }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
@@ -28,13 +28,13 @@ babel_monitor = { path = "../babel_monitor" }
 arrayvec = {version= "0.7", features = ["serde"]}
 sodiumoxide = "0.2"
 clu = { path = "../clu" }
-web30 = "0.22"
+web30 = { workspace = true }
 awc = "3.1"
 ipnetwork = "0.20"
 actix-async = {package="actix", version = "0.13"}
 actix-web-async = { package="actix-web", version = "4.3", default_features = false, features= ["openssl"]}
 actix-web-httpauth-async = { package="actix-web-httpauth", version = "0.8.0"}
-clarity = "0.5"
+clarity = { workspace = true }
 openssh-keys = "0.6"
 mac_address = "1.1.4"
 futures = { version = "0.3", features = ["compat"] }

--- a/rita_client/src/operator_fee_manager/mod.rs
+++ b/rita_client/src/operator_fee_manager/mod.rs
@@ -18,8 +18,6 @@ use althea_types::Identity;
 use althea_types::PaymentTx;
 use num256::Uint256;
 use rita_common::blockchain_oracle::get_oracle_balance;
-use rita_common::blockchain_oracle::get_oracle_latest_gas_price;
-use rita_common::blockchain_oracle::get_oracle_nonce;
 use rita_common::blockchain_oracle::get_pay_thresh;
 use rita_common::payment_controller::TRANSACTION_SUBMISSION_TIMEOUT;
 use rita_common::rita_loop::get_web3_server;
@@ -28,7 +26,6 @@ use rita_common::usage_tracker::update_payments;
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 use web30::client::Web3;
-use web30::types::SendTxOption;
 
 lazy_static! {
     static ref OPERATOR_FEE_DATA: Arc<RwLock<OperatorFeeManager>> =
@@ -81,10 +78,7 @@ pub async fn tick_operator_payments() {
     let operator_settings = client.operator;
     let payment_settings = common.payment;
     let eth_private_key = payment_settings.eth_private_key.unwrap();
-    let eth_address = payment_settings.eth_address.unwrap();
     let our_balance = get_oracle_balance();
-    let gas_price = get_oracle_latest_gas_price();
-    let nonce = get_oracle_nonce();
     let pay_threshold = get_pay_thresh();
     let operator_address = match operator_settings.operator_address {
         Some(val) => val,
@@ -126,19 +120,20 @@ pub async fn tick_operator_payments() {
         let full_node = get_web3_server();
         let web3 = Web3::new(&full_node, TRANSACTION_SUBMISSION_TIMEOUT);
 
-        let transaction_status = web3
-            .send_transaction(
+        let tx = web3
+            .prepare_transaction(
                 operator_address,
                 Vec::new(),
                 amount_to_pay.clone(),
-                eth_address,
                 eth_private_key,
-                vec![
-                    SendTxOption::Nonce(nonce.clone()),
-                    SendTxOption::GasPrice(gas_price),
-                ],
+                vec![],
             )
             .await;
+
+        let transaction_status = match tx {
+            Ok(tx) => web3.send_prepared_transaction(tx).await,
+            Err(e) => Err(e),
+        };
 
         // in theory this may fail to get into a block, for now there is no handler and
         // we will just underpay when that occurs. Failure to successfully submit the tx

--- a/rita_common/Cargo.toml
+++ b/rita_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rita_common"
-version = "0.20.39"
+version = "0.20.40"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/rita_common/Cargo.toml
+++ b/rita_common/Cargo.toml
@@ -22,9 +22,9 @@ auto-bridge = {path = "../auto_bridge"}
 serde_json = "1.0"
 log = { version = "0.4", features = ["release_max_level_info"] }
 settings = { path = "../settings" }
-clarity = "0.5"
+clarity = { workspace = true }
 futures = { version = "0.3", features = ["compat"] }
-num256 = "0.3"
+num256 = { workspace = true }
 num-traits="0.2"
 bincode = "1.3"
 serde_cbor = "0.11"
@@ -34,7 +34,7 @@ actix-web-httpauth-async = { package="actix-web-httpauth", version = "0.8.0"}
 actix-web-async = { package="actix-web", version = "4.3", default_features = false, features= ["openssl"]}
 awc = {version = "3.1", default-features = false, features=["openssl", "compress-gzip", "compress-zstd"]}
 actix-service = "2.0.2"
-web30 = "0.22"
+web30 = { workspace = true }
 althea_types = { path = "../althea_types" }
 crossbeam = "0.8"
 

--- a/rita_common/src/blockchain_oracle/mod.rs
+++ b/rita_common/src/blockchain_oracle/mod.rs
@@ -252,8 +252,7 @@ async fn update_blockchain_info(our_address: Address, web3: Web3, full_node: Str
     let balance = web3.eth_get_balance(our_address);
     let nonce = web3.eth_get_transaction_count(our_address);
     let gas_price = web3.eth_gas_price();
-    let (balance, nonce, gas_price) =
-        join3(balance, nonce, gas_price).await;
+    let (balance, nonce, gas_price) = join3(balance, nonce, gas_price).await;
 
     let mut settings = settings::get_rita_common();
 

--- a/rita_common/src/blockchain_oracle/mod.rs
+++ b/rita_common/src/blockchain_oracle/mod.rs
@@ -6,7 +6,7 @@
 use crate::rita_loop::fast_loop::FAST_LOOP_TIMEOUT;
 use crate::rita_loop::get_web3_server;
 use clarity::Address;
-use futures::future::join4;
+use futures::future::join3;
 use num256::Int256;
 use num256::Uint256;
 use settings::payment::PaymentSettings;
@@ -251,10 +251,9 @@ async fn update_blockchain_info(our_address: Address, web3: Web3, full_node: Str
 
     let balance = web3.eth_get_balance(our_address);
     let nonce = web3.eth_get_transaction_count(our_address);
-    let net_version = web3.net_version();
     let gas_price = web3.eth_gas_price();
-    let (balance, nonce, net_version, gas_price) =
-        join4(balance, nonce, net_version, gas_price).await;
+    let (balance, nonce, gas_price) =
+        join3(balance, nonce, gas_price).await;
 
     let mut settings = settings::get_rita_common();
 
@@ -265,12 +264,6 @@ async fn update_blockchain_info(our_address: Address, web3: Web3, full_node: Str
     match gas_price {
         Ok(gas_price) => update_gas_price(&full_node, gas_price, &mut settings.payment),
         Err(e) => warn!("Failed to update gas price with {:?}", e),
-    }
-    match net_version {
-        Ok(net_version) => {
-            check_net_version(&full_node, ORACLE.read().unwrap().net_version, net_version)
-        }
-        Err(e) => warn!("Failed to update net_version with {:?}", e),
     }
     match nonce {
         Ok(nonce) => update_nonce(&full_node, nonce, &mut ORACLE.write().unwrap().nonce),

--- a/rita_common/src/dashboard/own_info.rs
+++ b/rita_common/src/dashboard/own_info.rs
@@ -7,7 +7,7 @@ use actix_web_async::HttpResponse;
 use clarity::Address;
 use num256::{Int256, Uint256};
 
-pub static READABLE_VERSION: &str = "Beta 20 RC39";
+pub static READABLE_VERSION: &str = "Beta 20 RC40";
 
 #[derive(Serialize)]
 pub struct OwnInfo {

--- a/rita_common/src/dashboard/wallet.rs
+++ b/rita_common/src/dashboard/wallet.rs
@@ -1,6 +1,5 @@
 use crate::blockchain_oracle::get_oracle_balance;
 use crate::blockchain_oracle::get_oracle_latest_gas_price;
-use crate::blockchain_oracle::get_oracle_nonce;
 use crate::rita_loop::get_web3_server;
 use crate::token_bridge::setup_withdraw as bridge_withdraw;
 use crate::token_bridge::Withdraw as WithdrawMsg;
@@ -14,7 +13,6 @@ use std::sync::Arc;
 use std::sync::RwLock;
 use std::time::Duration;
 use web30::client::Web3;
-use web30::types::SendTxOption;
 
 // this is required until we migrate our endpoints to async actix
 // this way we can queue a withdraw from the old futures endpoint
@@ -114,19 +112,23 @@ pub async fn eth_compatible_withdraw() {
     let payment_settings = settings::get_rita_common().payment;
 
     if let Some((dest, amount)) = get_withdraw_queue() {
-        let transaction_status = web3
-            .send_transaction(
+        let tx = web3
+            .prepare_transaction(
                 dest,
                 Vec::new(),
                 amount.clone(),
-                payment_settings.eth_address.unwrap(),
                 payment_settings.eth_private_key.unwrap(),
-                vec![
-                    SendTxOption::Nonce(get_oracle_nonce()),
-                    SendTxOption::GasPrice(get_oracle_latest_gas_price()),
-                ],
+                vec![],
             )
             .await;
+        let tx = match tx {
+            Ok(tx) => tx,
+            Err(e) => {
+                error!("Failed to prepare withdrawal transaction: {:?}", e);
+                return;
+            }
+        };
+        let transaction_status = web3.send_prepared_transaction(tx).await;
         if let Err(e) = transaction_status {
             error!("Withdraw failed with {:?} retrying later!", e);
         } else {

--- a/rita_common/src/payment_controller/mod.rs
+++ b/rita_common/src/payment_controller/mod.rs
@@ -187,18 +187,32 @@ async fn make_payment(
     let web3 = Web3::new(&full_node, TRANSACTION_SUBMISSION_TIMEOUT);
 
     let tx = web3
-        .send_transaction(
+        .prepare_legacy_transaction(
             pmt.to.eth_address,
             Vec::new(),
             pmt.amount.clone(),
             our_private_key.to_address(),
             *our_private_key,
-            vec![],
+            vec![web30::types::SendTxOption::GasPriceMultiplier(1.2)],
         )
         .await;
 
     match tx {
-        Ok(tx_id) => {
+        Ok(tx) => {
+            let transaction_status = web3.send_prepared_transaction(tx.clone()).await;
+            let tx_id = match transaction_status {
+                Ok(tx_id) => tx_id,
+                Err(e) => {
+                    error!(
+                        "Failed to send payment {:?} to {:?} with {:?}",
+                        pmt, pmt.to, e
+                    );
+                    // it is now possible that this transaction has been published
+                    // so we have to try and determine what happened
+                    // the published state of the tx is ambiguous, now we have to pretend like we sent it.
+                    tx.txid()
+                }
+            };
             info!("Sending bw payment with txid {:#066x} current balance: {:?}, payment of {:?}, from address {} to address {}",
                             tx_id, balance, pmt.amount, our_address, pmt.to.eth_address);
 

--- a/rita_common/src/payment_validator/mod.rs
+++ b/rita_common/src/payment_validator/mod.rs
@@ -401,12 +401,29 @@ async fn validate_transaction(ts: ToValidate) -> Option<(ToValidate, TxValidatio
 fn get_xdai_transaction_details(
     transaction: TransactionResponse,
 ) -> (Option<Address>, Address, Uint256, Option<Uint256>) {
-    (
-        transaction.to,
-        transaction.from,
-        transaction.value,
-        transaction.block_number,
-    )
+    match transaction {
+        TransactionResponse::Eip1559 {
+            to,
+            from,
+            value,
+            block_number,
+            ..
+        } => (to, from, value, block_number),
+        TransactionResponse::Legacy {
+            to,
+            from,
+            value,
+            block_number,
+            ..
+        } => (to, from, value, block_number),
+        TransactionResponse::Eip2930 {
+            to,
+            from,
+            value,
+            block_number,
+            ..
+        } => (to, from, value, block_number),
+    }
 }
 
 /// A quick internal enum to encode the status of a transaction validation

--- a/rita_common/src/simulated_txfee_manager/mod.rs
+++ b/rita_common/src/simulated_txfee_manager/mod.rs
@@ -1,7 +1,5 @@
 //! The maintainer fee is a fraction of all payments that is sent to the firmware maintainer
 
-use crate::blockchain_oracle::get_oracle_latest_gas_price;
-use crate::blockchain_oracle::get_oracle_nonce;
 use crate::payment_controller::TRANSACTION_SUBMISSION_TIMEOUT;
 use crate::rita_loop::get_web3_server;
 use crate::usage_tracker::update_payments;
@@ -13,7 +11,6 @@ use num_traits::{Signed, Zero};
 use std::sync::Arc;
 use std::sync::RwLock;
 use web30::client::Web3;
-use web30::types::SendTxOption;
 
 lazy_static! {
     static ref AMOUNT_OWED: Arc<RwLock<Uint256>> = Arc::new(RwLock::new(Uint256::zero()));
@@ -40,13 +37,10 @@ pub fn add_tx_to_total(amount: Uint256) {
 pub async fn tick_simulated_tx() {
     let payment_settings = settings::get_rita_common().payment;
     let eth_private_key = payment_settings.eth_private_key.unwrap();
-    let eth_address = eth_private_key.to_address();
     let our_id = match settings::get_rita_common().get_identity() {
         Some(id) => id,
         None => return,
     };
-    let gas_price = get_oracle_latest_gas_price();
-    let nonce = get_oracle_nonce();
     let pay_threshold: Int256 = ONE_CENT.into();
     let simulated_transaction_fee_address = payment_settings.simulated_transaction_fee_address;
     let simulated_transaction_fee = payment_settings.simulated_transaction_fee;
@@ -77,21 +71,27 @@ pub async fn tick_simulated_tx() {
     let full_node = get_web3_server();
     let web3 = Web3::new(&full_node, TRANSACTION_SUBMISSION_TIMEOUT);
 
-    let transaction_status = web3.send_transaction(
-        simulated_transaction_fee_address,
-        Vec::new(),
-        amount_to_pay.clone(),
-        eth_address,
-        eth_private_key,
-        vec![
-            SendTxOption::Nonce(nonce.clone()),
-            SendTxOption::GasPrice(gas_price),
-        ],
-    );
+    let tx = web3
+        .prepare_transaction(
+            simulated_transaction_fee_address,
+            Vec::new(),
+            amount_to_pay.clone(),
+            eth_private_key,
+            vec![],
+        )
+        .await;
+    let tx = match tx {
+        Ok(tx) => tx,
+        Err(e) => {
+            error!("Failed to prepare simulated tx fee payment: {:?}", e);
+            return;
+        }
+    };
+    let transaction_status = web3.send_prepared_transaction(tx).await;
 
     // in theory this may fail, for now there is no handler and
     // we will just underpay when that occurs
-    match transaction_status.await {
+    match transaction_status {
         Ok(txid) => {
             info!("Successfully paid the simulated txfee {:#066x}!", txid);
             update_payments(PaymentTx {

--- a/rita_common/src/token_bridge/mod.rs
+++ b/rita_common/src/token_bridge/mod.rs
@@ -1,23 +1,23 @@
 // This module is designed to allow easy deposits for some supported chains using Ethereum. The idea
 // is pretty simple, the user deposits money into their routers Ethereum address, this is then exchanged
-// through uniswap into DAI and then from there it is bridged over to the Xdai proof of authority chains.
-// Support for Cosmos chains using a DAI-pegged native currency is next on the list.
+// through uniswap into USDS and then from there it is bridged over to the Xdai proof of authority chains.
+// Support for Cosmos chains using a USDS-pegged native currency is next on the list.
 
 // Essentially the goal is to allow users to deposit a popular and easy to acquire coin on Ethereum and then
 // actually transact in a stablecoin on a fast blockchain, eg not Ethereum.
 
-// Currently this flow supports USDC, USDT, and DAI itself (v2 specifically)
+// Currently this flow supports USDC, USDT, and USDS itself (v2 specifically)
 
 // This entire module works on the premise we call the conveyor belt model. It's difficult to track
 // money through this entire process exactly, in fact there are some edge cases where it's simply not
 // possible to reliably say if a task has completed or not. With that in mind we simply always progress
-// the the process for Source coin -> DAI -> XDAI.
+// the the process for Source coin -> USDS -> XDAI.
 
 // For the withdraw process we update a lazy static variable every time a withdraw is invoked.
 // Every tick, we check for updated withdraw information in the lazy static and use this to
 // initiate a withdrawal. From there, we loop to check for events related to the withdraws,
 // simulate these, and those that pass are unlocked on the eth side. Funds are sent to their final
-// destination in dai
+// destination in usds
 
 #[cfg(test)]
 mod tests;
@@ -45,7 +45,7 @@ pub const ETH_TRANSFER_TIMEOUT: Duration = Duration::from_secs(600);
 
 const WEI_PER_ETH: u128 = 1_000_000_000_000_000_000_u128;
 const SIGNATURES_TIMEOUT: Duration = ETH_TRANSFER_TIMEOUT;
-const BLOCKS: u64 = 40_032;
+const BLOCKS: u64 = 720;
 
 pub fn eth_to_wei(eth: u64) -> Uint256 {
     let wei = eth as u128 * WEI_PER_ETH;
@@ -123,7 +123,7 @@ pub struct Withdraw {
 }
 
 /// Since our withdraw function is async and cannot be called from the previous sync context
-/// we use this function to setup information about the withdrawal in the sync cUint256::from_bytes_be(&[12_u8])ontext. We setup
+/// we use this function to setup information about the withdrawal in the sync context. We setup
 /// a bool and Withdraw struct inside a lazy static variable that we can read from later when
 /// we initiate the withdrawal from an async context.
 pub fn setup_withdraw(msg: Withdraw) -> Result<(), RitaCommonError> {
@@ -164,7 +164,7 @@ pub async fn withdraw(msg: Withdraw) -> Result<(), RitaCommonError> {
     let token_bridge = token_bridge_core_from_settings(&payment_settings);
 
     let to = msg.to;
-    let amount = msg.amount.clone();
+    let amount = msg.amount;
 
     info!("bridge withdraw handler amount {}", amount);
 
@@ -174,11 +174,9 @@ pub async fn withdraw(msg: Withdraw) -> Result<(), RitaCommonError> {
         if !writer.withdraw_in_progress {
             writer.withdraw_in_progress = true;
             set_bridge_state(writer.clone());
-            let _res =
-                encode_relaytokens(token_bridge, to, amount.clone(), Duration::from_secs(600))
-                    .await;
+            let _res = encode_relaytokens(token_bridge, to, amount, Duration::from_secs(600)).await;
 
-            detailed_state_change(DetailedBridgeState::XdaiToDai { amount });
+            detailed_state_change(DetailedBridgeState::XdaiToUsds { amount });
             // Reset the lock
             writer.withdraw_in_progress = false;
             set_bridge_state(writer);
@@ -208,14 +206,14 @@ fn detailed_state_change(msg: DetailedBridgeState) {
 /// being inaccurate or going backwards
 #[derive(Debug, Eq, PartialEq, Clone, Serialize)]
 pub enum DetailedBridgeState {
-    /// Swapping any input token for dai
+    /// Swapping any input token for usds
     Swap,
-    /// Converting Dai to Xdai
-    DaiToXdai { amount: Uint256 },
-    /// Converting Xdai to Dai
-    XdaiToDai { amount: Uint256 },
-    DaiToDest {
-        amount_of_dai: Uint256,
+    /// Converting USDS to Xdai
+    UsdsToXdai { amount: Uint256 },
+    /// Converting Xdai to USDS
+    XdaiToUsds { amount: Uint256 },
+    UsdsToDest {
+        amount_of_usds: Uint256,
         dest_address: Address,
     },
     /// Nothing is happening

--- a/rita_common/src/token_bridge/tests.rs
+++ b/rita_common/src/token_bridge/tests.rs
@@ -210,7 +210,7 @@ fn test_transfer_dai() {
 
     let runner = actix_async::System::new();
     runner.block_on(async move {
-        let res = transfer_dai(bridge.clone(), bridge.get_dai_balance().await.unwrap()).await;
+        let res = transfer_usds(bridge.clone(), bridge.get_dai_balance().await.unwrap()).await;
         if res.is_err() {
             panic!("Failed to rescue dai with {:?}", res);
         }

--- a/rita_common/src/token_bridge/xdai_bridge.rs
+++ b/rita_common/src/token_bridge/xdai_bridge.rs
@@ -1,30 +1,34 @@
 use crate::token_bridge::*;
 use auto_bridge::check_relayed_message;
 use auto_bridge::get_payload_for_funds_unlock;
-use auto_bridge::get_usdt_address;
 use auto_bridge::HelperWithdrawInfo;
-use auto_bridge::MINIMUM_DAI_TO_SEND;
+use auto_bridge::MINIMUM_DAI_TO_CONVERT;
 use auto_bridge::MINIMUM_USDC_TO_CONVERT;
+use auto_bridge::MINIMUM_USDS_TO_SEND;
 use auto_bridge::{check_withdrawals, get_relay_message_hash};
 use auto_bridge::{TokenBridge as TokenBridgeCore, TokenBridgeError};
 use clarity::utils::display_uint256_as_address;
-use futures::future::join3;
+use futures::future::join4;
 use num256::Uint256;
 use rand::{thread_rng, Rng};
 use std::collections::HashSet;
+use std::vec;
 use web30::amm::DAI_CONTRACT_ADDRESS;
 use web30::amm::USDC_CONTRACT_ADDRESS;
+use web30::amm::USDS_CONTRACT_ADDRESS;
+use web30::amm::USDT_CONTRACT_ADDRESS;
 use web30::jsonrpc::error::Web3Error;
+use web30::types::TransactionRequest;
 
-/// Transfers dai present in eth address from previous xdai_bridge iterations to the xdai chain.
-/// This also assists in rescuing any stranded dai balance because of failures in depositing flow.
-pub async fn transfer_dai(
+/// Transfers usds present in eth address from previous xdai_bridge iterations to the xdai chain.
+/// This also assists in rescuing any stranded usds balance because of failures in depositing flow.
+pub async fn transfer_usds(
     bridge: TokenBridgeCore,
-    dai_balance: Uint256,
+    usds_balance: Uint256,
 ) -> Result<(), TokenBridgeError> {
-    info!("Our DAI balance is {}, sending to xDai!", dai_balance);
-    detailed_state_change(DetailedBridgeState::DaiToXdai {
-        amount: dai_balance.clone(),
+    info!("Our USDS balance is {}, sending to xDai!", usds_balance);
+    detailed_state_change(DetailedBridgeState::UsdsToXdai {
+        amount: usds_balance,
     });
 
     // Remove up to U16_MAX wei from this transaction, this is well under a cent.
@@ -34,11 +38,11 @@ pub async fn transfer_dai(
     // this is the only transaction that will be exactly the same for a very long period.
     let mut rng = thread_rng();
     let some_wei: u16 = rng.gen();
-    let amount = dai_balance - Uint256::from(some_wei);
+    let amount = usds_balance - Uint256::from(some_wei);
 
     // Over the bridge into xDai
     bridge
-        .dai_to_xdai_bridge(amount, ETH_TRANSFER_TIMEOUT)
+        .usds_to_xdai_bridge(amount, ETH_TRANSFER_TIMEOUT)
         .await?;
     Ok(())
 }
@@ -56,7 +60,7 @@ pub async fn process_withdraws(bridge: &TokenBridgeCore) -> bool {
                 return false;
             }
         };
-        let amount = withdraw_details.amount.clone();
+        let amount = withdraw_details.amount;
         let address = withdraw_details.to;
         match withdraw(withdraw_details).await {
             Ok(_) => {
@@ -96,16 +100,17 @@ pub async fn process_withdraws(bridge: &TokenBridgeCore) -> bool {
 /// on the xdai blockchain to find any withdrawals related to us, and if so we unlock these funds.
 /// We then rescue any stuck dai and send any eth that we have over to the xdai chain.
 pub async fn xdai_bridge(bridge: TokenBridgeCore) {
-    let (our_dai_balance, our_usdc_balance, our_usdt_balance) = join3(
-        bridge.get_dai_balance(),
+    let (our_usds_balance, our_usdc_balance, our_usdt_balance, our_dai_balance) = join4(
+        bridge.get_usds_balance(),
         bridge.get_usdc_balance(),
         bridge.get_usdt_balance(),
+        bridge.get_dai_balance(),
     )
     .await;
-    let our_dai_balance = match our_dai_balance {
+    let our_usds_balance = match our_usds_balance {
         Ok(val) => val,
         Err(e) => {
-            warn!("Failed to get our dai balance with {}", e);
+            warn!("Failed to get our usds balance with {}", e);
             return;
         }
     };
@@ -123,6 +128,13 @@ pub async fn xdai_bridge(bridge: TokenBridgeCore) {
             return;
         }
     };
+    let our_dai_balance = match our_dai_balance {
+        Ok(val) => val,
+        Err(e) => {
+            warn!("Failed to get our dai balance with {}", e);
+            return;
+        }
+    };
 
     // process withdraws, if any are processed be done for this iteration
     if process_withdraws(&bridge).await {
@@ -130,17 +142,24 @@ pub async fn xdai_bridge(bridge: TokenBridgeCore) {
     }
 
     info!(
-        "Our USDC balance is {} Our USDT balance is {} Minimum to convert is {}",
-        our_usdc_balance, our_usdt_balance, MINIMUM_USDC_TO_CONVERT
+        "Our USDC balance is {} Our USDT balance is {} our DAI balance is {} Minimum to convert is {}",
+        our_usdc_balance, our_usdt_balance, our_dai_balance, MINIMUM_USDC_TO_CONVERT
     );
     let mut token_to_swap = None;
+    let mut decimals_of_token_to_swap = 0u8;
     let mut token_amount = None;
     if our_usdc_balance >= MINIMUM_USDC_TO_CONVERT.into() {
         token_to_swap = Some(*USDC_CONTRACT_ADDRESS);
         token_amount = Some(our_usdc_balance);
+        decimals_of_token_to_swap = 6u8;
     } else if our_usdt_balance >= MINIMUM_USDC_TO_CONVERT.into() {
-        token_to_swap = Some(get_usdt_address());
+        token_to_swap = Some(*USDT_CONTRACT_ADDRESS);
         token_amount = Some(our_usdt_balance);
+        decimals_of_token_to_swap = 6u8;
+    } else if our_dai_balance >= MINIMUM_DAI_TO_CONVERT.into() {
+        token_to_swap = Some(*DAI_CONTRACT_ADDRESS);
+        token_amount = Some(our_dai_balance);
+        decimals_of_token_to_swap = 18u8;
     }
 
     if let (Some(token), Some(token_amount)) = (token_to_swap, token_amount) {
@@ -149,11 +168,11 @@ pub async fn xdai_bridge(bridge: TokenBridgeCore) {
             .swap_uniswap_v3(
                 bridge.eth_privatekey,
                 token,
-                *DAI_CONTRACT_ADDRESS,
-                Some(100u16.into()),
-                token_amount.clone(),
+                *USDS_CONTRACT_ADDRESS,
                 None,
-                Some(get_min_amount_out(token_amount)),
+                token_amount,
+                None,
+                Some(get_min_amount_out(token_amount, decimals_of_token_to_swap)),
                 None,
                 None,
                 None,
@@ -161,20 +180,20 @@ pub async fn xdai_bridge(bridge: TokenBridgeCore) {
             )
             .await;
         info!(
-            "Swap from {} to dai on uniswap returned with {:?}",
+            "Swap from {} to usds on uniswap returned with {:?}",
             token, res
         );
         detailed_state_change(DetailedBridgeState::Swap);
     }
 
     info!(
-        "Our dai balance {} minimum dai to send {}",
-        our_dai_balance, MINIMUM_DAI_TO_SEND
+        "Our usds balance {} minimum usds to send {}",
+        our_usds_balance, MINIMUM_USDS_TO_SEND
     );
-    if our_dai_balance >= MINIMUM_DAI_TO_SEND.into() {
-        // transfer dai exchanged from eth during previous iterations
-        let res = transfer_dai(bridge.clone(), our_dai_balance).await;
-        info!("DAI send to xdai returned with {:?}", res);
+    if our_usds_balance >= MINIMUM_USDS_TO_SEND.into() {
+        // transfer usds exchanged from eth during previous iterations
+        let res = transfer_usds(bridge.clone(), our_usds_balance).await;
+        info!("USDS send to xdai returned with {:?}", res);
         return;
     }
 
@@ -182,7 +201,7 @@ pub async fn xdai_bridge(bridge: TokenBridgeCore) {
 }
 
 /// This function is called inside the bridge loop. It retrieves the 'n' most recent blocks
-/// (where 'n' is the const 'BLOCKS' that is currently set to 40,032, which represents 1 week of blocks on xdai chain) that
+/// (where 'n' is the const 'BLOCKS' that is currently set to 720, which represents 1 hour of blocks on xdai chain) that
 /// have withdraw events related to our address. It then simulates these events and submits
 /// the signatures needed to unlock the funds.
 pub async fn simulated_withdrawal_on_eth(bridge: &TokenBridgeCore) -> Result<(), TokenBridgeError> {
@@ -190,25 +209,25 @@ pub async fn simulated_withdrawal_on_eth(bridge: &TokenBridgeCore) -> Result<(),
     let mut h = HashSet::new();
     h.insert(bridge.own_address);
 
-    let events = check_withdrawals(BLOCKS, bridge.xdai_bridge_on_xdai, client, h).await?;
+    let events = check_withdrawals(BLOCKS, bridge.xdai_bridge_on_xdai, client, h, None).await?;
 
     for event in events.iter() {
-        let txid = event.txid.clone();
-        let amount = event.amount.clone();
+        let txid = event.txid;
+        let amount = event.amount;
 
         let withdraw_info = get_relay_message_hash(
             bridge.own_address,
             bridge.xdai_web3.clone(),
             bridge.helper_on_xdai,
             event.receiver,
-            txid.clone(),
-            amount.clone(),
+            txid,
+            amount,
         )
         .await?;
 
         // check if the event has already unlocked the funds or not
         let res = match check_relayed_message(
-            event.txid.clone(),
+            event.txid,
             bridge.eth_web3.clone(),
             bridge.own_address,
             bridge.xdai_bridge_on_eth,
@@ -228,21 +247,21 @@ pub async fn simulated_withdrawal_on_eth(bridge: &TokenBridgeCore) -> Result<(),
         if res {
             trace!(
                 "Transaction with Id: {} has already been unlocked, skipping",
-                display_uint256_as_address(txid.clone())
+                display_uint256_as_address(txid)
             );
             continue;
         } else {
             //unlock this transaction
             trace!(
                 "Tx Hash is {} with the amount of {} for a withdraw event",
-                display_uint256_as_address(txid.clone()),
+                display_uint256_as_address(txid),
                 amount
             );
             let _res = bridge
                 .submit_signatures_to_unlock_funds(withdraw_info, SIGNATURES_TIMEOUT)
                 .await?;
-            detailed_state_change(DetailedBridgeState::DaiToDest {
-                amount_of_dai: amount,
+            detailed_state_change(DetailedBridgeState::UsdsToDest {
+                amount_of_usds: amount,
                 dest_address: event.receiver,
             });
         }
@@ -251,14 +270,16 @@ pub async fn simulated_withdrawal_on_eth(bridge: &TokenBridgeCore) -> Result<(),
     Ok(())
 }
 
-/// In order to avoid Ethereum dex sandwitch attacks we need to specify a minimum amount out of DAI
+/// In order to avoid Ethereum dex sandwitch attacks we need to specify a minimum amount out of USDS
 /// since both USDT and USDC are 6 decimal tokens this function simply does the decimal conversion to ensure
-/// we get 99% of the vlaue of our USDC or UDST out in DAI. If either token is depegged this will result in problems
-fn get_min_amount_out(mut input: Uint256) -> Uint256 {
-    // multiply by 1*10^12 to go from 1*10^6 value to -> 1*10^18 value
-    input *= 1_000_000_000_000u128.into();
-    // remove 2.5% off the top, so we need at least 95% of the face value of the USDC or USDT
-    input = input.clone() - input.clone() / 40u8.into();
+/// we get 99% of the vlaue of our USDC or UDST out in USDS. If either token is depegged this will result in problems
+/// decimals are the input token decimals, could be 6 for USDC/USDT or 18 for DAI
+fn get_min_amount_out(mut input: Uint256, decimals: u8) -> Uint256 {
+    // Convert to 18 decimals (USDS standard) by multiplying by 10^(18 - decimals)
+    let decimal_multiplier = 10u128.pow((18 - decimals) as u32);
+    input *= decimal_multiplier.into();
+    // remove 2.5% off the top, so we need at least 97.5% of the face value of the input token
+    input = input - input / 40u8.into();
     input
 }
 
@@ -274,10 +295,8 @@ pub async fn simulate_signature_submission(
     bridge
         .eth_web3
         .simulate_transaction(
-            bridge.xdai_bridge_on_eth,
-            0_u32.into(),
-            payload,
-            bridge.own_address,
+            TransactionRequest::quick_tx(bridge.own_address, bridge.xdai_bridge_on_eth, payload),
+            vec![],
             None,
         )
         .await

--- a/rita_common/src/usage_tracker/tests.rs
+++ b/rita_common/src/usage_tracker/tests.rs
@@ -171,7 +171,7 @@ pub mod test {
         ip.copy_from_slice(&secret[0..16]);
 
         // the starting location of the funds
-        let eth_key = PrivateKey::from_slice(&secret).unwrap();
+        let eth_key = PrivateKey::from_bytes(secret).unwrap();
         let eth_address = eth_key.to_address();
 
         Identity {

--- a/rita_exit/Cargo.toml
+++ b/rita_exit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rita_exit"
-version = "0.20.39"
+version = "0.20.40"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/rita_exit/Cargo.toml
+++ b/rita_exit/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 # debug is used here to make sure exit logs remain accessible locally
 compressed_log = {version="0.5", features = ["debug"]}
 sodiumoxide = "0.2"
-num256 = "0.3"
+num256 = { workspace = true }
 rita_common = { path = "../rita_common" }
 althea_kernel_interface = { path = "../althea_kernel_interface" }
 althea_types = { path = "../althea_types" }
@@ -21,7 +21,7 @@ handlebars = "4.0"
 rand = "0.8.0"
 lazy_static = "1.4"
 ipnetwork = "0.20"
-clarity = "0.5"
+clarity = { workspace = true }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/rita_exit/src/lib.rs
+++ b/rita_exit/src/lib.rs
@@ -103,7 +103,6 @@ pub fn init_db_pool(db_uri: String, workers: u32) -> Pool<ConnectionManager<PgCo
         .max_size(workers + 1)
         .build(manager)
         .expect("Failed to create pool. Check exit IP is trusted to access postgresql")
-
 }
 
 lazy_static! {

--- a/rita_extender/Cargo.toml
+++ b/rita_extender/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rita_extender"
-version = "0.20.39"
+version = "0.20.40"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/scripts/integration_tests/quick-check.sh
+++ b/scripts/integration_tests/quick-check.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# script for easily running all tests
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+set -eux
+bash $SCRIPT_DIR/run-tests.sh FIVE_NODES
+bash $SCRIPT_DIR/run-tests.sh PAYMENTS_ETH
+bash $SCRIPT_DIR/run-tests.sh PAYMENTS_ALTHEA
+bash $SCRIPT_DIR/run-tests.sh MULTI_EXIT
+bash $SCRIPT_DIR/run-tests.sh DEBTS

--- a/settings/Cargo.toml
+++ b/settings/Cargo.toml
@@ -9,14 +9,14 @@ althea_types = { path = "../althea_types"}
 babel_monitor = { path = "../babel_monitor"}
 althea_kernel_interface = { path = "../althea_kernel_interface" }
 auto-bridge = { path = "../auto_bridge" }
-num256 = "0.3"
+num256 = { workspace = true }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 toml = "0.5"
 log = "0.4"
 lazy_static = "1.4"
-clarity = "0.5"
+clarity = { workspace = true }
 arrayvec = {version= "0.7", features = ["serde"]}
 phonenumber = "0.3"
 ipnetwork = "0.20"


### PR DESCRIPTION
This patch updates the beta20 branch to the latest clarity and web30 versions which adds support for eip1559 transactions and the large number of quality of life improvements that have been incorporated into these libraries since beta20 was created.

This is being done mostly to handle gnosis payment failures when updating Nethermind to the latest version (v1.35)

- Replace Web3::send_transaction with prepare_transaction/prepare_legacy_transaction + send_prepared_transaction
- Replace PrivateKey::from_slice with PrivateKey::from_bytes
- Remove net_version tracking (removed from web30 API)
- Update TransactionResponse access to match on enum variants (Eip1559/Legacy/Eip2930)